### PR TITLE
fix(extensions): ensure __init__.py in extension dir is present

### DIFF
--- a/gen_proto.sh
+++ b/gen_proto.sh
@@ -27,5 +27,8 @@ rm -rf "$extension_dir"
 cp -fr "$submodule_dir"/extensions "$extension_dir"
 find "$extension_dir" -type f -exec chmod u+rw {} +
 
+# Ensure there's an __init__.py file in the extension directory
+touch $extension_dir/__init__.py
+
 # Remove the temporary work dir
 rm -rf "$tmp_dir"


### PR DESCRIPTION
`gen_proto.sh` was deleting this file (or not recreating it) and if it isn't present, 
then it isn't possible to grab the extension yaml files in Python using `importlib.resources.files`.

This restores the missing __init__.py file and also adds a `touch` to the 
`gen_proto.sh` script to make sure it sticks around.