### PR TITLE
chore(bash): update script per shellcheck recs

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -12,13 +12,13 @@ VERSION=$1
 echo "Updating substrait submodule..."
 git submodule update --remote third_party/substrait
 
-DIR=$(cd $(dirname $0) && pwd)
-pushd "${DIR}"/third_party/substrait/
-git checkout $VERSION
+DIR=$(cd "$(dirname "$0")" && pwd)
+pushd "${DIR}"/third_party/substrait/ || exit
+git checkout "$VERSION"
 SUBSTRAIT_HASH=$(git rev-parse --short HEAD)
-popd
+popd || exit
 
-VERSION=$(echo $VERSION | sed 's/v//')
+VERSION=${VERSION//v/}
 
 sed -i "s#__substrait_hash__.*#__substrait_hash__ = \"$SUBSTRAIT_HASH\"#g" src/substrait/__init__.py
 sed -i "s#__substrait_version__.*#__substrait_version__ = \"$VERSION\"#g" src/substrait/__init__.py


### PR DESCRIPTION
Periodically I remember that `shellcheck` exists.  Today was one of those days and so I've made a 
few small syntax changes to the update script to avoid some common bashy gotchas.
