### PR TITLE
chore(substrait): bump to v0.39.0

### DIFF
--- a/src/substrait/__init__.py
+++ b/src/substrait/__init__.py
@@ -3,6 +3,6 @@ try:
 except ImportError:
     pass
 
-__substrait_version__ = "0.38.0"
-__substrait_hash__ = "bdff923"
+__substrait_version__ = "0.39.0"
+__substrait_hash__ = "8f8d85e"
 __minimum_substrait_version__ = "0.30.0"


### PR DESCRIPTION
Note, this contains a breaking change in map behavior.

See https://github.com/substrait-io/substrait/releases/tag/v0.39.0 for
more info.
