### PR TITLE
feat: add ruff pre-commit hook for format and lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,7 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.1.6
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  autofix_commit_msg: "style: [pre-commit.ci] autofix"
+  autoupdate_commit_msg: "chore(deps): [pre-commit.ci] autoupdate"
+
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
   rev: v0.1.6

--- a/environment.yml
+++ b/environment.yml
@@ -4,6 +4,7 @@ channels:
 dependencies:
   - buf
   - pip
+  - pre-commit
   - protobuf = 3.20.1  # protobuf==3.20 C extensions aren't compatible with 3.19.4
   - protoletariat >= 2.0.0
   - pytest >= 7.0.0


### PR DESCRIPTION
This PR adds the ruff pre-commit hook for format and lint.