### PR TITLE
chore(ruff): configure ruff behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,15 @@ pythonpath = "src"
 [build-system]
 requires = ["setuptools>=61.0.0", "setuptools_scm[toml]>=6.2.0"]
 build-backend = "setuptools.build_meta"
+
+[tool.ruff]
+respect-gitignore = true
+# should target minimum supported version
+target-version = "py38"
+# never autoformat upstream or generated code
+exclude = ["third_party/", "src/substrait/gen"]
+# do not autofix the following (will still get flagged in lint)
+unfixable = [
+  "F401",  # unused imports
+  "T201",  # print statements
+]

--- a/src/substrait/__init__.py
+++ b/src/substrait/__init__.py
@@ -1,5 +1,5 @@
 try:
-    from ._version import __version__
+    from ._version import __version__  # noqa: F401
 except ImportError:
     pass
 

--- a/tests/test_proto.py
+++ b/tests/test_proto.py
@@ -1,3 +1,6 @@
+# ruff: noqa: F401
+
+
 def test_imports():
     """Temporary sanity test"""
     from substrait.gen.proto.algebra_pb2 import Expression


### PR DESCRIPTION
Ignore third-party and generated files.
Add a few `noqa` to test imports and exposing `__version__`.
Ensure that it doesn't write non-Py38 compatible code.

Forbid `ruff` from automatically "fixing" unused imports and print statements.

Followup to #36 