### PR TITLE
feat: add type inference

### DIFF
--- a/src/substrait/type_inference.py
+++ b/src/substrait/type_inference.py
@@ -56,7 +56,7 @@ def infer_literal_type(literal: stalg.Expression.Literal) -> stt.Type:
     elif literal_type == "struct":
         return stt.Type(struct=stt.Type.Struct(types=[infer_literal_type(f) for f in literal.struct.fields], nullability=nullability))
     elif literal_type == "map":
-        return stt.Type(map=stt.Type.Map(key=infer_literal_type(literal.map.key_values[0].key), value=infer_literal_type(literal.map.key_values[0].value)), nullability=nullability)
+        return stt.Type(map=stt.Type.Map(key=infer_literal_type(literal.map.key_values[0].key), value=infer_literal_type(literal.map.key_values[0].value), nullability=nullability))
     elif literal_type == "timestamp_tz":
         return stt.Type(timestamp_tz=stt.Type.TimestampTZ(nullability=nullability))
     elif literal_type == "uuid":

--- a/src/substrait/type_inference.py
+++ b/src/substrait/type_inference.py
@@ -27,6 +27,48 @@ def infer_literal_type(literal: stalg.Expression.Literal) -> stt.Type:
         return stt.Type(fp64=stt.Type.FP64(nullability=nullability))
     elif literal_type == "string":
         return stt.Type(string=stt.Type.String(nullability=nullability))
+    elif literal_type == "binary":
+        return stt.Type(binary=stt.Type.Binary(nullability=nullability))
+    elif literal_type == "timestamp":
+        return stt.Type(timestamp=stt.Type.Timestamp(nullability=nullability))
+    elif literal_type == "date":
+        return stt.Type(date=stt.Type.Date(nullability=nullability))
+    elif literal_type == "time":
+        return stt.Type(time=stt.Type.Time(nullability=nullability))
+    elif literal_type == "interval_year_to_month":
+        return stt.Type(interval_year=stt.Type.IntervalYear(nullability=nullability))
+    elif literal_type == "interval_day_to_second":
+        return stt.Type(interval_day=stt.Type.IntervalDay(precision=literal.interval_day_to_second.precision, nullability=nullability))
+    elif literal_type == "interval_compound":
+        return stt.Type(interval_compound=stt.Type.IntervalCompound(nullability=nullability, precision=literal.interval_compound.interval_day_to_second.precision))
+    elif literal_type == "fixed_char":
+        return stt.Type(fixed_char=stt.Type.FixedChar(length=len(literal.fixed_char), nullability=nullability))
+    elif literal_type == "var_char":
+        return stt.Type(varchar=stt.Type.VarChar(length=literal.var_char.length, nullability=nullability))
+    elif literal_type == "fixed_binary":
+        return stt.Type(fixed_binary=stt.Type.FixedBinary(length=len(literal.fixed_binary), nullability=nullability))
+    elif literal_type == "decimal":
+        return stt.Type(decimal=stt.Type.Decimal(scale=literal.decimal.scale, precision=literal.decimal.precision, nullability=nullability))
+    elif literal_type == "precision_timestamp":
+        return stt.Type(precision_timestamp=stt.Type.PrecisionTimestamp(precision=literal.precision_timestamp.precision, nullability=nullability))
+    elif literal_type == "precision_timestamp_tz":
+        return stt.Type(precision_timestamp_tz=stt.Type.PrecisionTimestampTZ(precision=literal.precision_timestamp_tz.precision, nullability=nullability))
+    elif literal_type == "struct":
+        return stt.Type(struct=stt.Type.Struct(types=[infer_literal_type(f) for f in literal.struct.fields], nullability=nullability))
+    elif literal_type == "map":
+        return stt.Type(map=stt.Type.Map(key=infer_literal_type(literal.map.key_values[0].key), value=infer_literal_type(literal.map.key_values[0].value)), nullability=nullability)
+    elif literal_type == "timestamp_tz":
+        return stt.Type(timestamp_tz=stt.Type.TimestampTZ(nullability=nullability))
+    elif literal_type == "uuid":
+        return stt.Type(uuid=stt.Type.UUID(nullability=nullability))
+    elif literal_type == "null":
+        return literal.null
+    elif literal_type == "list":
+        return stt.Type(list=stt.Type.List(type=infer_literal_type(literal.list.values[0]), nullability=nullability))
+    elif literal_type == "empty_list":
+        return stt.Type(list=literal.empty_list)
+    elif literal_type == "empty_map":
+        return stt.Type(map=literal.empty_map)
     else:
         raise Exception(f"Unknown literal_type {literal_type}")
 

--- a/src/substrait/type_inference.py
+++ b/src/substrait/type_inference.py
@@ -38,25 +38,73 @@ def infer_literal_type(literal: stalg.Expression.Literal) -> stt.Type:
     elif literal_type == "interval_year_to_month":
         return stt.Type(interval_year=stt.Type.IntervalYear(nullability=nullability))
     elif literal_type == "interval_day_to_second":
-        return stt.Type(interval_day=stt.Type.IntervalDay(precision=literal.interval_day_to_second.precision, nullability=nullability))
+        return stt.Type(
+            interval_day=stt.Type.IntervalDay(
+                precision=literal.interval_day_to_second.precision,
+                nullability=nullability,
+            )
+        )
     elif literal_type == "interval_compound":
-        return stt.Type(interval_compound=stt.Type.IntervalCompound(nullability=nullability, precision=literal.interval_compound.interval_day_to_second.precision))
+        return stt.Type(
+            interval_compound=stt.Type.IntervalCompound(
+                nullability=nullability,
+                precision=literal.interval_compound.interval_day_to_second.precision,
+            )
+        )
     elif literal_type == "fixed_char":
-        return stt.Type(fixed_char=stt.Type.FixedChar(length=len(literal.fixed_char), nullability=nullability))
+        return stt.Type(
+            fixed_char=stt.Type.FixedChar(
+                length=len(literal.fixed_char), nullability=nullability
+            )
+        )
     elif literal_type == "var_char":
-        return stt.Type(varchar=stt.Type.VarChar(length=literal.var_char.length, nullability=nullability))
+        return stt.Type(
+            varchar=stt.Type.VarChar(
+                length=literal.var_char.length, nullability=nullability
+            )
+        )
     elif literal_type == "fixed_binary":
-        return stt.Type(fixed_binary=stt.Type.FixedBinary(length=len(literal.fixed_binary), nullability=nullability))
+        return stt.Type(
+            fixed_binary=stt.Type.FixedBinary(
+                length=len(literal.fixed_binary), nullability=nullability
+            )
+        )
     elif literal_type == "decimal":
-        return stt.Type(decimal=stt.Type.Decimal(scale=literal.decimal.scale, precision=literal.decimal.precision, nullability=nullability))
+        return stt.Type(
+            decimal=stt.Type.Decimal(
+                scale=literal.decimal.scale,
+                precision=literal.decimal.precision,
+                nullability=nullability,
+            )
+        )
     elif literal_type == "precision_timestamp":
-        return stt.Type(precision_timestamp=stt.Type.PrecisionTimestamp(precision=literal.precision_timestamp.precision, nullability=nullability))
+        return stt.Type(
+            precision_timestamp=stt.Type.PrecisionTimestamp(
+                precision=literal.precision_timestamp.precision, nullability=nullability
+            )
+        )
     elif literal_type == "precision_timestamp_tz":
-        return stt.Type(precision_timestamp_tz=stt.Type.PrecisionTimestampTZ(precision=literal.precision_timestamp_tz.precision, nullability=nullability))
+        return stt.Type(
+            precision_timestamp_tz=stt.Type.PrecisionTimestampTZ(
+                precision=literal.precision_timestamp_tz.precision,
+                nullability=nullability,
+            )
+        )
     elif literal_type == "struct":
-        return stt.Type(struct=stt.Type.Struct(types=[infer_literal_type(f) for f in literal.struct.fields], nullability=nullability))
+        return stt.Type(
+            struct=stt.Type.Struct(
+                types=[infer_literal_type(f) for f in literal.struct.fields],
+                nullability=nullability,
+            )
+        )
     elif literal_type == "map":
-        return stt.Type(map=stt.Type.Map(key=infer_literal_type(literal.map.key_values[0].key), value=infer_literal_type(literal.map.key_values[0].value), nullability=nullability))
+        return stt.Type(
+            map=stt.Type.Map(
+                key=infer_literal_type(literal.map.key_values[0].key),
+                value=infer_literal_type(literal.map.key_values[0].value),
+                nullability=nullability,
+            )
+        )
     elif literal_type == "timestamp_tz":
         return stt.Type(timestamp_tz=stt.Type.TimestampTZ(nullability=nullability))
     elif literal_type == "uuid":
@@ -64,13 +112,18 @@ def infer_literal_type(literal: stalg.Expression.Literal) -> stt.Type:
     elif literal_type == "null":
         return literal.null
     elif literal_type == "list":
-        return stt.Type(list=stt.Type.List(type=infer_literal_type(literal.list.values[0]), nullability=nullability))
+        return stt.Type(
+            list=stt.Type.List(
+                type=infer_literal_type(literal.list.values[0]), nullability=nullability
+            )
+        )
     elif literal_type == "empty_list":
         return stt.Type(list=literal.empty_list)
     elif literal_type == "empty_map":
         return stt.Type(map=literal.empty_map)
     else:
         raise Exception(f"Unknown literal_type {literal_type}")
+
 
 def infer_nested_type(nested: stalg.Expression.Nested) -> stt.Type:
     nested_type = nested.WhichOneof("nested_type")
@@ -82,13 +135,30 @@ def infer_nested_type(nested: stalg.Expression.Nested) -> stt.Type:
     )
 
     if nested_type == "struct":
-        return stt.Type(struct=stt.Type.Struct(types=[infer_expression_type(f) for f in nested.struct.fields], nullability=nullability))
+        return stt.Type(
+            struct=stt.Type.Struct(
+                types=[infer_expression_type(f) for f in nested.struct.fields],
+                nullability=nullability,
+            )
+        )
     elif nested_type == "list":
-        return stt.Type(list=stt.Type.List(type=infer_expression_type(nested.list.values[0]), nullability=nullability))
+        return stt.Type(
+            list=stt.Type.List(
+                type=infer_expression_type(nested.list.values[0]),
+                nullability=nullability,
+            )
+        )
     elif nested_type == "map":
-        return stt.Type(map=stt.Type.Map(key=infer_expression_type(nested.map.key_values[0].key), value=infer_expression_type(nested.map.key_values[0].value), nullability=nullability))
+        return stt.Type(
+            map=stt.Type.Map(
+                key=infer_expression_type(nested.map.key_values[0].key),
+                value=infer_expression_type(nested.map.key_values[0].value),
+                nullability=nullability,
+            )
+        )
     else:
         raise Exception(f"Unknown nested_type {nested_type}")
+
 
 def infer_expression_type(
     expression: stalg.Expression, parent_schema: stt.Type.Struct
@@ -131,17 +201,24 @@ def infer_expression_type(
     elif rex_type == "nested":
         return infer_nested_type(expression.nested)
     elif rex_type == "subquery":
-        subquery_type = expression.subquery.WhichOneof('subquery_type')
+        subquery_type = expression.subquery.WhichOneof("subquery_type")
 
         if subquery_type == "scalar":
             scalar_rel = infer_rel_schema(expression.subquery.scalar.input)
             return scalar_rel.types[0]
-        elif subquery_type == "in_predicate" or subquery_type == "set_comparison" or subquery_type == "set_predicate":
-            stt.Type.Boolean(nullability=stt.Type.Nullability.NULLABILITY_NULLABLE) # can this be a null?
+        elif (
+            subquery_type == "in_predicate"
+            or subquery_type == "set_comparison"
+            or subquery_type == "set_predicate"
+        ):
+            stt.Type.Boolean(
+                nullability=stt.Type.Nullability.NULLABILITY_NULLABLE
+            )  # can this be a null?
         else:
             raise Exception(f"Unknown subquery_type {subquery_type}")
     else:
         raise Exception(f"Unknown rex_type {rex_type}")
+
 
 def infer_rel_schema(rel: stalg.Rel) -> stt.Type.Struct:
     rel_type = rel.WhichOneof("rel_type")
@@ -154,11 +231,20 @@ def infer_rel_schema(rel: stalg.Rel) -> stt.Type.Struct:
         (common, struct) = (rel.fetch.common, infer_rel_schema(rel.fetch.input))
     elif rel_type == "aggregate":
         parent_schema = infer_rel_schema(rel.aggregate.input)
-        grouping_types = [infer_expression_type(g, parent_schema) for g in rel.aggregate.grouping_expressions]
+        grouping_types = [
+            infer_expression_type(g, parent_schema)
+            for g in rel.aggregate.grouping_expressions
+        ]
         measure_types = [m.measure.output_type for m in rel.aggregate.measures]
 
+        grouping_identifier_types = (
+            []
+            if len(rel.aggregate.groupings) <= 1
+            else [stt.Type(i32=stt.Type.I32(nullability=stt.Type.NULLABILITY_REQUIRED))]
+        )
+
         raw_schema = stt.Type.Struct(
-            types=grouping_types + measure_types,
+            types=grouping_types + measure_types + grouping_identifier_types,
             nullability=parent_schema.nullability,
         )
 

--- a/tests/test_literal_type_inference.py
+++ b/tests/test_literal_type_inference.py
@@ -3,7 +3,7 @@ import substrait.gen.proto.algebra_pb2 as stalg
 import substrait.gen.proto.type_pb2 as stt
 from substrait.type_inference import infer_literal_type
 
-pairs = [
+testcases = [
     (
         stalg.Expression.Literal(boolean=True, nullable=True),
         stt.Type(bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_NULLABLE)),
@@ -308,6 +308,6 @@ pairs = [
 ]
 
 
-@pytest.mark.parametrize("pair", pairs)
-def test_inference_literal_bool(pair):
-    assert infer_literal_type(pair[0]) == pair[1]
+@pytest.mark.parametrize("testcase", testcases)
+def test_inference_literal_bool(testcase):
+    assert infer_literal_type(testcase[0]) == testcase[1]

--- a/tests/test_literal_type_inference.py
+++ b/tests/test_literal_type_inference.py
@@ -1,0 +1,313 @@
+import pytest
+import substrait.gen.proto.algebra_pb2 as stalg
+import substrait.gen.proto.type_pb2 as stt
+from substrait.type_inference import infer_literal_type
+
+pairs = [
+    (
+        stalg.Expression.Literal(boolean=True, nullable=True),
+        stt.Type(bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(i8=100, nullable=True),
+        stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(i16=100, nullable=True),
+        stt.Type(i16=stt.Type.I16(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(i32=100, nullable=True),
+        stt.Type(i32=stt.Type.I32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(i64=100, nullable=True),
+        stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(fp32=100.5, nullable=True),
+        stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(fp64=100.5, nullable=True),
+        stt.Type(fp64=stt.Type.FP64(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(string="substrait", nullable=True),
+        stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(binary=b"\xde", nullable=True),
+        stt.Type(binary=stt.Type.Binary(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(timestamp=1000000, nullable=True),
+        stt.Type(
+            timestamp=stt.Type.Timestamp(nullability=stt.Type.NULLABILITY_NULLABLE)
+        ),
+    ),
+    (
+        stalg.Expression.Literal(date=1000, nullable=True),
+        stt.Type(date=stt.Type.Date(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(time=1000, nullable=True),
+        stt.Type(time=stt.Type.Time(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(
+            interval_year_to_month=stalg.Expression.Literal.IntervalYearToMonth(
+                years=1, months=5
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            interval_year=stt.Type.IntervalYear(
+                nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            interval_day_to_second=stalg.Expression.Literal.IntervalDayToSecond(
+                days=1, seconds=100
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            interval_day=stt.Type.IntervalDay(
+                precision=0, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            interval_day_to_second=stalg.Expression.Literal.IntervalDayToSecond(
+                days=1, seconds=100, precision=3, subseconds=10
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            interval_day=stt.Type.IntervalDay(
+                precision=3, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            interval_compound=stalg.Expression.Literal.IntervalCompound(
+                interval_year_to_month=stalg.Expression.Literal.IntervalYearToMonth(
+                    years=1, months=5
+                ),
+                interval_day_to_second=stalg.Expression.Literal.IntervalDayToSecond(
+                    days=1, seconds=100
+                ),
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            interval_compound=stt.Type.IntervalCompound(
+                precision=0, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            fixed_char="substrait",
+            nullable=True,
+        ),
+        stt.Type(
+            fixed_char=stt.Type.FixedChar(
+                length=9, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            var_char=stalg.Expression.Literal.VarChar(value="substrait", length=10),
+            nullable=True,
+        ),
+        stt.Type(
+            varchar=stt.Type.VarChar(
+                length=10, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            fixed_binary=b"substrait",
+            nullable=True,
+        ),
+        stt.Type(
+            fixed_binary=stt.Type.FixedBinary(
+                length=9, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            decimal=stalg.Expression.Literal.Decimal(
+                value=b"somenumber", precision=10, scale=2
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            decimal=stt.Type.Decimal(
+                precision=10, scale=2, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            precision_timestamp=stalg.Expression.Literal.PrecisionTimestamp(
+                precision=3, value=1000
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            precision_timestamp=stt.Type.PrecisionTimestamp(
+                precision=3, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            precision_timestamp_tz=stalg.Expression.Literal.PrecisionTimestamp(
+                precision=3, value=1000
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            precision_timestamp_tz=stt.Type.PrecisionTimestampTZ(
+                precision=3, nullability=stt.Type.NULLABILITY_NULLABLE
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            struct=stalg.Expression.Literal.Struct(
+                fields=[
+                    stalg.Expression.Literal(boolean=True, nullable=False),
+                    stalg.Expression.Literal(i8=100, nullable=False),
+                ]
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            struct=stt.Type.Struct(
+                types=[
+                    stt.Type(
+                        bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)
+                    ),
+                    stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)),
+                ],
+                nullability=stt.Type.NULLABILITY_NULLABLE,
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            map=stalg.Expression.Literal.Map(
+                key_values=[
+                    stalg.Expression.Literal.Map.KeyValue(
+                        key=stalg.Expression.Literal(boolean=True, nullable=False),
+                        value=stalg.Expression.Literal(i8=100, nullable=False),
+                    )
+                ],
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            map=stt.Type.Map(
+                key=stt.Type(
+                    bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                value=stt.Type(
+                    i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                nullability=stt.Type.NULLABILITY_NULLABLE,
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            uuid=b"uuid",
+            nullable=True,
+        ),
+        stt.Type(uuid=stt.Type.UUID(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(
+            null=stt.Type(
+                bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_NULLABLE)
+            ),
+            nullable=False,  # this should be ignored
+        ),
+        stt.Type(bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ),
+    (
+        stalg.Expression.Literal(
+            list=stalg.Expression.Literal.List(
+                values=[stalg.Expression.Literal(i8=100, nullable=False)],
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            list=stt.Type.List(
+                type=stt.Type(
+                    i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                nullability=stt.Type.NULLABILITY_NULLABLE,
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            empty_list=stt.Type.List(
+                type=stt.Type(
+                    i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                nullability=stt.Type.NULLABILITY_REQUIRED,
+            ),
+            nullable=True,
+        ),
+        stt.Type(
+            list=stt.Type.List(
+                type=stt.Type(
+                    i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                nullability=stt.Type.NULLABILITY_REQUIRED,
+            )
+        ),
+    ),
+    (
+        stalg.Expression.Literal(
+            empty_map=stt.Type.Map(
+                key=stt.Type(
+                    bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                value=stt.Type(
+                    i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                nullability=stt.Type.NULLABILITY_NULLABLE,
+            ),
+            nullable=False,
+        ),
+        stt.Type(
+            map=stt.Type.Map(
+                key=stt.Type(
+                    bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                value=stt.Type(
+                    i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)
+                ),
+                nullability=stt.Type.NULLABILITY_NULLABLE,
+            )
+        ),
+    ),
+]
+
+
+@pytest.mark.parametrize("pair", pairs)
+def test_inference_literal_bool(pair):
+    assert infer_literal_type(pair[0]) == pair[1]

--- a/tests/test_type_inference.py
+++ b/tests/test_type_inference.py
@@ -1,0 +1,99 @@
+import substrait.gen.proto.algebra_pb2 as stalg
+import substrait.gen.proto.type_pb2 as stt
+from substrait.type_inference import infer_rel_schema
+
+
+struct = stt.Type.Struct(
+    types=[
+        stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+        stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ]
+)
+
+named_struct = stt.NamedStruct(
+    names=["order_id", "description", "order_total"], struct=struct
+)
+
+read_rel = stalg.Rel(
+    read=stalg.ReadRel(
+        base_schema=named_struct, named_table=stalg.ReadRel.NamedTable(names=["table"])
+    )
+)
+
+
+def test_inference_read_named_table():
+    assert infer_rel_schema(read_rel) == struct
+
+
+def test_inference_project_emit():
+    rel = stalg.Rel(
+        project=stalg.ProjectRel(
+            input=read_rel,
+            common=stalg.RelCommon(emit=stalg.RelCommon.Emit(output_mapping=[0, 2])),
+        )
+    )
+
+    expected = stt.Type.Struct(
+        types=[
+            stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+            stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+        ]
+    )
+
+    assert infer_rel_schema(rel) == expected
+
+
+def test_inference_project_literal():
+    rel = stalg.Rel(
+        project=stalg.ProjectRel(
+            input=read_rel,
+            expressions=[
+                stalg.Expression(
+                    literal=stalg.Expression.Literal(boolean=True, nullable=False)
+                )
+            ],
+        )
+    )
+
+    expected = stt.Type.Struct(
+        types=[
+            stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+            stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+            stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+            stt.Type(bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        ]
+    )
+
+    assert infer_rel_schema(rel) == expected
+
+
+def test_inference_project_scalar_function():
+    rel = stalg.Rel(
+        project=stalg.ProjectRel(
+            input=read_rel,
+            expressions=[
+                stalg.Expression(
+                    scalar_function=stalg.Expression.ScalarFunction(
+                        function_reference=0,
+                        output_type=stt.Type(
+                            bool=stt.Type.Boolean(
+                                nullability=stt.Type.NULLABILITY_REQUIRED
+                            )
+                        ),
+                    )
+                )
+            ],
+        )
+    )
+
+    expected = stt.Type.Struct(
+        types=[
+            stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+            stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+            stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+            stt.Type(bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        ]
+    )
+
+    assert infer_rel_schema(rel) == expected

--- a/tests/test_type_inference.py
+++ b/tests/test_type_inference.py
@@ -142,3 +142,53 @@ def test_inference_aggregate():
     )
 
     assert infer_rel_schema(rel) == expected
+
+
+def test_inference_aggregate_multiple_groupings():
+    rel = stalg.Rel(
+        aggregate=stalg.AggregateRel(
+            input=read_rel,
+            grouping_expressions=[
+                stalg.Expression(
+                    selection=stalg.Expression.FieldReference(
+                        root_reference=stalg.Expression.FieldReference.RootReference(),
+                        direct_reference=stalg.Expression.ReferenceSegment(
+                            struct_field=stalg.Expression.ReferenceSegment.StructField(
+                                field=1,
+                            ),
+                        ),
+                    )
+                )
+            ],
+            groupings=[
+                stalg.AggregateRel.Grouping(
+                    expression_references=[]
+                ),
+                stalg.AggregateRel.Grouping(
+                    expression_references=[0]
+                )
+            ],
+            measures=[
+                stalg.AggregateRel.Measure(
+                    measure=stalg.AggregateFunction(
+                        function_reference=0,
+                        output_type=stt.Type(
+                            bool=stt.Type.Boolean(
+                                nullability=stt.Type.NULLABILITY_REQUIRED
+                            )
+                        ),
+                    )
+                )
+            ],
+        )
+    )
+
+    expected = stt.Type.Struct(
+        types=[
+            stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+            stt.Type(bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)),
+            stt.Type(i32=stt.Type.I32(nullability=stt.Type.NULLABILITY_REQUIRED))
+        ]
+    )
+
+    assert infer_rel_schema(rel) == expected

--- a/tests/test_type_inference.py
+++ b/tests/test_type_inference.py
@@ -97,3 +97,48 @@ def test_inference_project_scalar_function():
     )
 
     assert infer_rel_schema(rel) == expected
+
+def test_inference_aggregate():
+    rel = stalg.Rel(
+        aggregate=stalg.AggregateRel(
+            input=read_rel,
+            grouping_expressions=[
+                stalg.Expression(
+                    selection=stalg.Expression.FieldReference(
+                        root_reference=stalg.Expression.FieldReference.RootReference(),
+                        direct_reference=stalg.Expression.ReferenceSegment(
+                            struct_field=stalg.Expression.ReferenceSegment.StructField(
+                                field=1,
+                            ),
+                        ),
+                    )
+                )
+            ],
+            groupings=[
+                stalg.AggregateRel.Grouping(
+                    expression_references=[0]
+                )
+            ],
+            measures=[
+                stalg.AggregateRel.Measure(
+                    measure=stalg.AggregateFunction(
+                        function_reference=0,
+                        output_type=stt.Type(
+                            bool=stt.Type.Boolean(
+                                nullability=stt.Type.NULLABILITY_REQUIRED
+                            )
+                        ),
+                    )
+                )
+            ],
+        )
+    )
+
+    expected = stt.Type.Struct(
+        types=[
+            stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+            stt.Type(bool=stt.Type.Boolean(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        ]
+    )
+
+    assert infer_rel_schema(rel) == expected


### PR DESCRIPTION
Adds helper functions that infer expression types and rel schemas from substrait.
The implementation is not yet meant to be exhaustive, it covers a subset of types/expressions/rels. 