### PR TITLE
feat: add registry for extension functions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,9 @@ dynamic = ["version"]
 write_to = "src/substrait/_version.py"
 
 [project.optional-dependencies]
-extensions = ["antlr4-python3-runtime"]
+extensions = ["antlr4-python3-runtime", "pyyaml"]
 gen_proto = ["protobuf == 3.20.1", "protoletariat >= 2.0.0"]
-test = ["pytest >= 7.0.0", "antlr4-python3-runtime"]
+test = ["pytest >= 7.0.0", "antlr4-python3-runtime", "pyyaml"]
 
 [tool.pytest.ini_options]
 pythonpath = "src"
@@ -31,7 +31,7 @@ target-version = "py39"
 # never autoformat upstream or generated code
 exclude = ["third_party/", "src/substrait/gen"]
 # do not autofix the following (will still get flagged in lint)
-unfixable = [
+lint.unfixable = [
   "F401",  # unused imports
   "T201",  # print statements
 ]

--- a/src/substrait/derivation_expression.py
+++ b/src/substrait/derivation_expression.py
@@ -48,27 +48,39 @@ def _evaluate(x, values: dict):
         scalar_type = x.scalarType()
         parametrized_type = x.parameterizedType()
         if scalar_type:
+            nullability = (
+                Type.NULLABILITY_NULLABLE if x.isnull else Type.NULLABILITY_REQUIRED
+            )
             if isinstance(scalar_type, SubstraitTypeParser.I8Context):
-                return Type(i8=Type.I8())
+                return Type(i8=Type.I8(nullability=nullability))
             elif isinstance(scalar_type, SubstraitTypeParser.I16Context):
-                return Type(i16=Type.I16())
+                return Type(i16=Type.I16(nullability=nullability))
             elif isinstance(scalar_type, SubstraitTypeParser.I32Context):
-                return Type(i32=Type.I32())
+                return Type(i32=Type.I32(nullability=nullability))
             elif isinstance(scalar_type, SubstraitTypeParser.I64Context):
-                return Type(i64=Type.I64())
+                return Type(i64=Type.I64(nullability=nullability))
             elif isinstance(scalar_type, SubstraitTypeParser.Fp32Context):
-                return Type(fp32=Type.FP32())
+                return Type(fp32=Type.FP32(nullability=nullability))
             elif isinstance(scalar_type, SubstraitTypeParser.Fp64Context):
-                return Type(fp64=Type.FP64())
+                return Type(fp64=Type.FP64(nullability=nullability))
             elif isinstance(scalar_type, SubstraitTypeParser.BooleanContext):
-                return Type(bool=Type.Boolean())
+                return Type(bool=Type.Boolean(nullability=nullability))
             else:
                 raise Exception(f"Unknown scalar type {type(scalar_type)}")
         elif parametrized_type:
             if isinstance(parametrized_type, SubstraitTypeParser.DecimalContext):
                 precision = _evaluate(parametrized_type.precision, values)
                 scale = _evaluate(parametrized_type.scale, values)
-                return Type(decimal=Type.Decimal(precision=precision, scale=scale))
+                nullability = (
+                    Type.NULLABILITY_NULLABLE
+                    if parametrized_type.isnull
+                    else Type.NULLABILITY_REQUIRED
+                )
+                return Type(
+                    decimal=Type.Decimal(
+                        precision=precision, scale=scale, nullability=nullability
+                    )
+                )
             raise Exception(f"Unknown parametrized type {type(parametrized_type)}")
         else:
             raise Exception("either scalar_type or parametrized_type is required")

--- a/src/substrait/derivation_expression.py
+++ b/src/substrait/derivation_expression.py
@@ -37,7 +37,6 @@ def _evaluate(x, values: dict):
     elif type(x) == SubstraitTypeParser.FunctionCallContext:
         exprs = [_evaluate(e, values) for e in x.expr()]
         func = x.Identifier().symbol.text
-
         if func == "min":
             return min(*exprs)
         elif func == "max":
@@ -103,12 +102,18 @@ def _evaluate(x, values: dict):
         return _evaluate(x.finalType, values)
     elif type(x) == SubstraitTypeParser.TypeLiteralContext:
         return _evaluate(x.type_(), values)
+    elif type(x) == SubstraitTypeParser.NumericLiteralContext:
+        return int(str(x.Number()))
     else:
         raise Exception(f"Unknown token type {type(x)}")
 
 
-def evaluate(x: str, values: Optional[dict] = None):
+def _parse(x: str):
     lexer = SubstraitTypeLexer(InputStream(x))
     stream = CommonTokenStream(lexer)
     parser = SubstraitTypeParser(stream)
-    return _evaluate(parser.expr(), values)
+    return parser.expr()
+
+
+def evaluate(x: str, values: Optional[dict] = None):
+    return _evaluate(_parse(x), values)

--- a/src/substrait/function_registry.py
+++ b/src/substrait/function_registry.py
@@ -50,9 +50,6 @@ def normalize_substrait_type_names(typ: str) -> str:
     return typ
 
 
-id_generator = itertools.count(1)
-
-
 def to_integer_option(txt: str):
     if txt.isnumeric():
         return ParameterizedType.IntegerOption(literal=int(txt))
@@ -153,7 +150,7 @@ def to_parameterized_type(dtype: str):
             user_defined=ParameterizedType.ParameterizedUserDefined()
         )
     else:
-        raise Exception(f"Unkownn type - {dtype}")
+        raise Exception(f"Unknown type - {dtype}")
 
 
 def violates_integer_option(
@@ -210,11 +207,11 @@ def covers(dtype: Type, parameterized_type: ParameterizedType, parameters: dict)
 
 
 class FunctionEntry:
-    def __init__(self, uri: str, name: str, impl: Mapping[str, Any]) -> None:
+    def __init__(self, uri: str, name: str, impl: Mapping[str, Any], anchor: int) -> None:
         self.name = name
         self.normalized_inputs: list = []
         self.uri: str = uri
-        self.anchor = next(id_generator)
+        self.anchor = anchor
         self.arguments = []
         self.rtn = impl["return"]
         self.nullability = impl.get("nullability", False)
@@ -286,7 +283,7 @@ class FunctionRegistry:
         for named_functions in definitions.values():
             for function in named_functions:
                 for impl in function.get("impls", []):
-                    func = FunctionEntry(uri, function["name"], impl)
+                    func = FunctionEntry(uri, function["name"], impl, next(self.id_generator))
                     if (
                         func.uri in self._function_mapping
                         and function["name"] in self._function_mapping[func.uri]

--- a/src/substrait/function_registry.py
+++ b/src/substrait/function_registry.py
@@ -1,0 +1,316 @@
+from substrait.gen.proto.parameterized_types_pb2 import ParameterizedType
+from substrait.gen.proto.type_pb2 import Type
+from importlib.resources import files as importlib_files
+import itertools
+from collections import defaultdict
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Optional, Union
+from .derivation_expression import evaluate
+
+import yaml
+import re
+
+_normalized_key_names = {
+    "binary": "vbin",
+    "interval_compound": "icompound",
+    "interval_day": "iday",
+    "interval_year": "iyear",
+    "string": "str",
+    "timestamp": "ts",
+    "timestamp_tz": "tstz",
+}
+
+
+def normalize_substrait_type_names(typ: str) -> str:
+    # First strip off any punctuation
+    typ = typ.strip("?").lower()
+
+    # Common prefixes whose information does not matter to an extension function
+    # signature
+    for complex_type, abbr in [
+        ("fixedchar", "fchar"),
+        ("varchar", "vchar"),
+        ("fixedbinary", "fbin"),
+        ("decimal", "dec"),
+        ("precision_timestamp", "pts"),
+        ("precision_timestamp_tz", "ptstz"),
+        ("struct", "struct"),
+        ("list", "list"),
+        ("map", "map"),
+        ("any", "any"),
+        ("boolean", "bool"),
+    ]:
+        if typ.lower().startswith(complex_type):
+            typ = abbr
+
+    # Then pass through the dictionary of mappings, defaulting to just the
+    # existing string
+    typ = _normalized_key_names.get(typ.lower(), typ.lower())
+    return typ
+
+
+id_generator = itertools.count(1)
+
+
+def to_integer_option(txt: str):
+    if txt.isnumeric():
+        return ParameterizedType.IntegerOption(literal=int(txt))
+    else:
+        return ParameterizedType.IntegerOption(
+            parameter=ParameterizedType.IntegerParameter(name=txt)
+        )
+
+
+def to_parameterized_type(dtype: str):
+    if dtype == "boolean":
+        return ParameterizedType(bool=Type.Boolean())
+    elif dtype == "i8":
+        return ParameterizedType(i8=Type.I8())
+    elif dtype == "i16":
+        return ParameterizedType(i16=Type.I16())
+    elif dtype == "i32":
+        return ParameterizedType(i32=Type.I32())
+    elif dtype == "i64":
+        return ParameterizedType(i64=Type.I64())
+    elif dtype == "fp32":
+        return ParameterizedType(fp32=Type.FP32())
+    elif dtype == "fp64":
+        return ParameterizedType(fp64=Type.FP64())
+    elif dtype == "timestamp":
+        return ParameterizedType(timestamp=Type.Timestamp())
+    elif dtype == "timestamp_tz":
+        return ParameterizedType(timestamp_tz=Type.TimestampTZ())
+    elif dtype == "date":
+        return ParameterizedType(date=Type.Date())
+    elif dtype == "time":
+        return ParameterizedType(time=Type.Time())
+    elif dtype == "interval_year":
+        return ParameterizedType(interval_year=Type.IntervalYear())
+    elif dtype.startswith("decimal") or dtype.startswith("DECIMAL"):
+        (_, precision, scale, _) = re.split(r"\W+", dtype)
+
+        return ParameterizedType(
+            decimal=ParameterizedType.ParameterizedDecimal(
+                scale=to_integer_option(scale), precision=to_integer_option(precision)
+            )
+        )
+    elif dtype.startswith("varchar"):
+        (_, length, _) = re.split(r"\W+", dtype)
+
+        return ParameterizedType(
+            varchar=ParameterizedType.ParameterizedVarChar(
+                length=to_integer_option(length)
+            )
+        )
+    elif dtype.startswith("precision_timestamp"):
+        (_, precision, _) = re.split(r"\W+", dtype)
+
+        return ParameterizedType(
+            precision_timestamp=ParameterizedType.ParameterizedPrecisionTimestamp(
+                precision=to_integer_option(precision)
+            )
+        )
+    elif dtype.startswith("precision_timestamp_tz"):
+        (_, precision, _) = re.split(r"\W+", dtype)
+
+        return ParameterizedType(
+            precision_timestamp_tz=ParameterizedType.ParameterizedPrecisionTimestampTZ(
+                precision=to_integer_option(precision)
+            )
+        )
+    elif dtype.startswith("fixedchar"):
+        (_, length, _) = re.split(r"\W+", dtype)
+
+        return ParameterizedType(
+            fixed_char=ParameterizedType.ParameterizedFixedChar(
+                length=to_integer_option(length)
+            )
+        )
+    elif dtype == "string":
+        return ParameterizedType(string=Type.String())
+    elif dtype.startswith("list"):
+        inner_dtype = dtype[5:-1]
+        return ParameterizedType(
+            list=ParameterizedType.ParameterizedList(
+                type=to_parameterized_type(inner_dtype)
+            )
+        )
+    elif dtype.startswith("interval_day"):
+        (_, precision, _) = re.split(r"\W+", dtype)
+
+        return ParameterizedType(
+            interval_day=ParameterizedType.ParameterizedIntervalDay(
+                precision=to_integer_option(precision)
+            )
+        )
+    elif dtype.startswith("any"):
+        return ParameterizedType(
+            type_parameter=ParameterizedType.TypeParameter(name=dtype)
+        )
+    elif dtype.startswith("u!") or dtype == "geometry":
+        return ParameterizedType(
+            user_defined=ParameterizedType.ParameterizedUserDefined()
+        )
+    else:
+        raise Exception(f"Unkownn type - {dtype}")
+
+
+def violates_integer_option(
+    actual: int, option: ParameterizedType.IntegerOption, parameters: dict
+):
+    integer_type = option.WhichOneof("integer_type")
+
+    if integer_type == "literal" and actual != option.literal:
+        return True
+    else:
+        parameter_name = option.parameter.name
+        if parameter_name in parameters and parameters[parameter_name] != actual:
+            return True
+        else:
+            parameters[parameter_name] = actual
+
+    return False
+
+
+def covers(dtype: Type, parameterized_type: ParameterizedType, parameters: dict):
+    expected_kind = parameterized_type.WhichOneof("kind")
+
+    if expected_kind == "type_parameter":
+        parameter_name = parameterized_type.type_parameter.name
+        if parameter_name == "any":
+            return True
+        else:
+            if parameter_name in parameters and parameters[
+                parameter_name
+            ].SerializeToString(deterministic=True) != dtype.SerializeToString(
+                deterministic=True
+            ):
+                return False
+            else:
+                parameters[parameter_name] = dtype
+                return True
+
+    kind = dtype.WhichOneof("kind")
+
+    if kind != expected_kind:
+        return False
+
+    if kind == "decimal":
+        if violates_integer_option(
+            dtype.decimal.scale, parameterized_type.decimal.scale, parameters
+        ) or violates_integer_option(
+            dtype.decimal.precision, parameterized_type.decimal.precision, parameters
+        ):
+            return False
+
+    # TODO handle all types
+
+    return True
+
+
+class FunctionEntry:
+    def __init__(self, uri: str, name: str, impl: Mapping[str, Any]) -> None:
+        self.name = name
+        self.normalized_inputs: list = []
+        self.uri: str = uri
+        self.anchor = next(id_generator)
+        self.arguments = []
+        self.rtn = impl["return"]
+        self.nullability = impl.get("nullability", False)
+        self.variadic = impl.get("variadic", False)
+        if input_args := impl.get("args", []):
+            for val in input_args:
+                if typ := val.get("value"):
+                    self.arguments.append(to_parameterized_type(typ.strip("?")))
+                    self.normalized_inputs.append(normalize_substrait_type_names(typ))
+                elif arg_name := val.get("name", None):
+                    self.arguments.append(val.get("options"))
+                    self.normalized_inputs.append("req")
+
+    def __repr__(self) -> str:
+        return f"{self.name}:{'_'.join(self.normalized_inputs)}"
+
+    def satisfies_signature(self, signature: tuple) -> Optional[str]:
+        if self.variadic:
+            min_args_allowed = self.variadic.get("min", 0)
+            if len(signature) < min_args_allowed:
+                return None
+            inputs = [self.arguments[0]] * len(signature)
+        else:
+            inputs = self.arguments
+        if len(inputs) != len(signature):
+            return None
+
+        zipped_args = list(zip(inputs, signature))
+
+        parameters = {}
+
+        for x, y in zipped_args:
+            if type(y) == str:
+                if y not in x:
+                    return None
+            else:
+                if not covers(y, x, parameters):
+                    return None
+
+        return evaluate(self.rtn, parameters)
+
+
+class FunctionRegistry:
+    def __init__(self) -> None:
+        self._function_mapping: dict = defaultdict(dict)
+        self.id_generator = itertools.count(1)
+
+        self.uri_aliases = {}
+
+        for fpath in importlib_files("substrait.extensions").glob(  # type: ignore
+            "functions*.yaml"
+        ):
+            uri = f"https://github.com/substrait-io/substrait/blob/main/extensions/{fpath.name}"
+            self.uri_aliases[fpath.name] = uri
+            self.register_extension_yaml(fpath, uri)
+
+    def register_extension_yaml(
+        self,
+        fname: Union[str, Path],
+        uri: str,
+    ) -> None:
+        fname = Path(fname)
+        with open(fname) as f:  # type: ignore
+            extension_definitions = yaml.safe_load(f)
+
+        self.register_extension_dict(extension_definitions, uri)
+
+    def register_extension_dict(self, definitions: dict, uri: str) -> None:
+        for named_functions in definitions.values():
+            for function in named_functions:
+                for impl in function.get("impls", []):
+                    func = FunctionEntry(uri, function["name"], impl)
+                    if (
+                        func.uri in self._function_mapping
+                        and function["name"] in self._function_mapping[func.uri]
+                    ):
+                        self._function_mapping[func.uri][function["name"]].append(func)
+                    else:
+                        self._function_mapping[func.uri][function["name"]] = [func]
+
+    # TODO add an optional return type check
+    def lookup_function(
+        self, uri: str, function_name: str, signature: tuple
+    ) -> Optional[tuple[FunctionEntry, Type]]:
+        uri = self.uri_aliases.get(uri, uri)
+
+        if (
+            uri not in self._function_mapping
+            or function_name not in self._function_mapping[uri]
+        ):
+            return None
+        functions = self._function_mapping[uri][function_name]
+        for f in functions:
+            assert isinstance(f, FunctionEntry)
+            rtn = f.satisfies_signature(signature)
+            if rtn is not None:
+                return (f, rtn)
+
+        return None

--- a/src/substrait/function_registry.py
+++ b/src/substrait/function_registry.py
@@ -6,10 +6,9 @@ from collections import defaultdict
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, Optional, Union
-from .derivation_expression import evaluate
+from .derivation_expression import evaluate, _evaluate, _parse
 
 import yaml
-import re
 
 
 DEFAULT_URI_PREFIX = "https://github.com/substrait-io/substrait/blob/main/extensions"
@@ -57,193 +56,104 @@ def normalize_substrait_type_names(typ: str) -> str:
         return "any"
     elif typ.startswith("u!"):
         return typ
-    else:
+    elif typ in _normalized_key_names:
         return _normalized_key_names[typ]
-
-
-def to_integer_option(txt: str):
-    if txt.isnumeric():
-        return ParameterizedType.IntegerOption(literal=int(txt))
     else:
-        return ParameterizedType.IntegerOption(
-            parameter=ParameterizedType.IntegerParameter(name=txt)
-        )
+        raise Exception(f"Unrecognized substrait type {typ}")
 
 
-# TODO try using antlr grammar here as well
-def to_parameterized_type(dtype: str):
-    if "?" in dtype:
-        dtype = dtype.replace("?", "")
-        nullability = Type.NULLABILITY_NULLABLE
-    else:
-        nullability = Type.NULLABILITY_REQUIRED
-
-    if dtype == "boolean":
-        return ParameterizedType(bool=Type.Boolean(nullability=nullability))
-    elif dtype == "i8":
-        return ParameterizedType(i8=Type.I8(nullability=nullability))
-    elif dtype == "i16":
-        return ParameterizedType(i16=Type.I16(nullability=nullability))
-    elif dtype == "i32":
-        return ParameterizedType(i32=Type.I32(nullability=nullability))
-    elif dtype == "i64":
-        return ParameterizedType(i64=Type.I64(nullability=nullability))
-    elif dtype == "fp32":
-        return ParameterizedType(fp32=Type.FP32(nullability=nullability))
-    elif dtype == "fp64":
-        return ParameterizedType(fp64=Type.FP64(nullability=nullability))
-    elif dtype == "timestamp":
-        return ParameterizedType(timestamp=Type.Timestamp(nullability=nullability))
-    elif dtype == "timestamp_tz":
-        return ParameterizedType(timestamp_tz=Type.TimestampTZ(nullability=nullability))
-    elif dtype == "date":
-        return ParameterizedType(date=Type.Date(nullability=nullability))
-    elif dtype == "time":
-        return ParameterizedType(time=Type.Time(nullability=nullability))
-    elif dtype == "interval_year":
-        return ParameterizedType(
-            interval_year=Type.IntervalYear(nullability=nullability)
-        )
-    elif dtype.startswith("decimal") or dtype.startswith("DECIMAL"):
-        (_, precision, scale, _) = re.split(r"\W+", dtype)
-
-        return ParameterizedType(
-            decimal=ParameterizedType.ParameterizedDecimal(
-                scale=to_integer_option(scale),
-                precision=to_integer_option(precision),
-                nullability=nullability,
-            )
-        )
-    elif dtype.startswith("varchar"):
-        (_, length, _) = re.split(r"\W+", dtype)
-
-        return ParameterizedType(
-            varchar=ParameterizedType.ParameterizedVarChar(
-                length=to_integer_option(length), nullability=nullability
-            )
-        )
-    elif dtype.startswith("precision_timestamp"):
-        (_, precision, _) = re.split(r"\W+", dtype)
-
-        return ParameterizedType(
-            precision_timestamp=ParameterizedType.ParameterizedPrecisionTimestamp(
-                precision=to_integer_option(precision), nullability=nullability
-            )
-        )
-    elif dtype.startswith("precision_timestamp_tz"):
-        (_, precision, _) = re.split(r"\W+", dtype)
-
-        return ParameterizedType(
-            precision_timestamp_tz=ParameterizedType.ParameterizedPrecisionTimestampTZ(
-                precision=to_integer_option(precision), nullability=nullability
-            )
-        )
-    elif dtype.startswith("fixedchar"):
-        (_, length, _) = re.split(r"\W+", dtype)
-
-        return ParameterizedType(
-            fixed_char=ParameterizedType.ParameterizedFixedChar(
-                length=to_integer_option(length), nullability=nullability
-            )
-        )
-    elif dtype == "string":
-        return ParameterizedType(string=Type.String(nullability=nullability))
-    elif dtype.startswith("list"):
-        inner_dtype = dtype[5:-1]
-        return ParameterizedType(
-            list=ParameterizedType.ParameterizedList(
-                type=to_parameterized_type(inner_dtype), nullability=nullability
-            )
-        )
-    elif dtype.startswith("interval_day"):
-        (_, precision, _) = re.split(r"\W+", dtype)
-
-        return ParameterizedType(
-            interval_day=ParameterizedType.ParameterizedIntervalDay(
-                precision=to_integer_option(precision), nullability=nullability
-            )
-        )
-    elif dtype.startswith("any"):
-        return ParameterizedType(
-            type_parameter=ParameterizedType.TypeParameter(name=dtype)
-        )
-    elif dtype.startswith("u!") or dtype == "geometry":
-        return ParameterizedType(
-            user_defined=ParameterizedType.ParameterizedUserDefined(
-                nullability=nullability
-            )
-        )
-    else:
-        raise Exception(f"Unknown type - {dtype}")
-
-
-def violates_integer_option(
-    actual: int, option: ParameterizedType.IntegerOption, parameters: dict
-):
-    integer_type = option.WhichOneof("integer_type")
-
-    if integer_type == "literal" and actual != option.literal:
-        return True
-    else:
-        parameter_name = option.parameter.name
+def violates_integer_option(actual: int, option, parameters: dict):
+    if isinstance(option, SubstraitTypeParser.NumericLiteralContext):
+        return actual != int(str(option.Number()))
+    elif isinstance(option, SubstraitTypeParser.NumericParameterNameContext):
+        parameter_name = str(option.Identifier())
         if parameter_name in parameters and parameters[parameter_name] != actual:
             return True
         else:
             parameters[parameter_name] = actual
+    else:
+        raise Exception(
+            f"Input should be either NumericLiteralContext or NumericParameterNameContext, got {type(option)} instead"
+        )
 
     return False
 
 
+from substrait.gen.antlr.SubstraitTypeParser import SubstraitTypeParser
+
+
+def types_equal(type1: Type, type2: Type, check_nullability=False):
+    if check_nullability:
+        return type1 == type2
+    else:
+        x, y = Type(), Type()
+        x.CopyFrom(type1)
+        y.CopyFrom(type2)
+        x.__getattribute__(
+            x.WhichOneof("kind")
+        ).nullability = Type.Nullability.NULLABILITY_UNSPECIFIED
+        y.__getattribute__(
+            y.WhichOneof("kind")
+        ).nullability = Type.Nullability.NULLABILITY_UNSPECIFIED
+        return x == y
+
+
 def covers(
-    dtype: Type,
-    parameterized_type: ParameterizedType,
+    covered: Type,
+    covering: SubstraitTypeParser.TypeLiteralContext,
     parameters: dict,
     check_nullability=False,
 ):
-    expected_kind = parameterized_type.WhichOneof("kind")
+    if isinstance(covering, SubstraitTypeParser.TypeParamContext):
+        parameter_name = str(covering.Identifier())
 
-    if expected_kind == "type_parameter":
-        parameter_name = parameterized_type.type_parameter.name
-        # TODO figure out how to do nullability checks with "any" types
-        if parameter_name == "any":
-            return True
+        if parameter_name in parameters:
+            covering = parameters[parameter_name]
+
+            return types_equal(covering, covered, check_nullability)
         else:
-            if parameter_name in parameters and parameters[
-                parameter_name
-            ].SerializeToString(deterministic=True) != dtype.SerializeToString(
-                deterministic=True
+            parameters[parameter_name] = covered
+            return True
+
+    covering = covering.type_()
+    scalar_type = covering.scalarType()
+    if scalar_type:
+        covering = _evaluate(covering, {})
+        return types_equal(covering, covered, check_nullability)
+
+    parameterized_type = covering.parameterizedType()
+    if parameterized_type:
+        if isinstance(parameterized_type, SubstraitTypeParser.DecimalContext):
+            if covered.WhichOneof("kind") != "decimal":
+                return False
+
+            nullability = (
+                Type.NULLABILITY_NULLABLE
+                if parameterized_type.isnull
+                else Type.NULLABILITY_REQUIRED
+            )
+
+            if (
+                check_nullability
+                and nullability
+                != covered.__getattribute__(covered.WhichOneof("kind")).nullability
             ):
                 return False
-            else:
-                parameters[parameter_name] = dtype
-                return True
 
-    expected_nullability = parameterized_type.__getattribute__(
-        parameterized_type.WhichOneof("kind")
-    ).nullability
+            return not (
+                violates_integer_option(
+                    covered.decimal.scale, parameterized_type.scale, parameters
+                )
+                or violates_integer_option(
+                    covered.decimal.precision, parameterized_type.precision, parameters
+                )
+            )
+        else:
+            raise Exception(f"Unhandled type {type(parameterized_type)}")
 
-    kind = dtype.WhichOneof("kind")
-
-    if kind != expected_kind:
-        return False
-
-    if (
-        check_nullability
-        and dtype.__getattribute__(dtype.WhichOneof("kind")).nullability
-        != expected_nullability
-    ):
-        return False
-
-    if kind == "decimal":
-        if violates_integer_option(
-            dtype.decimal.scale, parameterized_type.decimal.scale, parameters
-        ) or violates_integer_option(
-            dtype.decimal.precision, parameterized_type.decimal.precision, parameters
-        ):
-            return False
-
-    # TODO handle all types
-    return True
+    any_type = covering.anyType()
+    if any_type:
+        return True
 
 
 class FunctionEntry:
@@ -261,7 +171,7 @@ class FunctionEntry:
         if input_args := impl.get("args", []):
             for val in input_args:
                 if typ := val.get("value"):
-                    self.arguments.append(to_parameterized_type(typ))
+                    self.arguments.append(_parse(typ))
                     self.normalized_inputs.append(normalize_substrait_type_names(typ))
                 elif arg_name := val.get("name", None):
                     self.arguments.append(val.get("options"))
@@ -296,7 +206,6 @@ class FunctionEntry:
                     return None
 
         output_type = evaluate(self.rtn, parameters)
-        print(output_type)
 
         if self.nullability == "MIRROR":
             sig_contains_nullable = any(

--- a/tests/test_derivation_expression.py
+++ b/tests/test_derivation_expression.py
@@ -24,29 +24,59 @@ def test_ternary():
 
 
 def test_multiline():
-    assert (
-        evaluate(
-            """temp = min(var, 7) + max(var, 7)
+    assert evaluate(
+        """temp = min(var, 7) + max(var, 7)
 decimal<temp + 1, temp - 1>""",
-            {"var": 5},
+        {"var": 5},
+    ) == Type(
+        decimal=Type.Decimal(
+            precision=13, scale=11, nullability=Type.NULLABILITY_REQUIRED
         )
-        == Type(decimal=Type.Decimal(precision=13, scale=11))
     )
 
 
 def test_simple_data_types():
-    assert evaluate("i8") == Type(i8=Type.I8())
-    assert evaluate("i16") == Type(i16=Type.I16())
-    assert evaluate("i32") == Type(i32=Type.I32())
-    assert evaluate("i64") == Type(i64=Type.I64())
-    assert evaluate("fp32") == Type(fp32=Type.FP32())
-    assert evaluate("fp64") == Type(fp64=Type.FP64())
-    assert evaluate("boolean") == Type(bool=Type.Boolean())
+    assert evaluate("i8") == Type(i8=Type.I8(nullability=Type.NULLABILITY_REQUIRED))
+    assert evaluate("i16") == Type(i16=Type.I16(nullability=Type.NULLABILITY_REQUIRED))
+    assert evaluate("i32") == Type(i32=Type.I32(nullability=Type.NULLABILITY_REQUIRED))
+    assert evaluate("i64") == Type(i64=Type.I64(nullability=Type.NULLABILITY_REQUIRED))
+    assert evaluate("fp32") == Type(
+        fp32=Type.FP32(nullability=Type.NULLABILITY_REQUIRED)
+    )
+    assert evaluate("fp64") == Type(
+        fp64=Type.FP64(nullability=Type.NULLABILITY_REQUIRED)
+    )
+    assert evaluate("boolean") == Type(
+        bool=Type.Boolean(nullability=Type.NULLABILITY_REQUIRED)
+    )
+    assert evaluate("i8?") == Type(i8=Type.I8(nullability=Type.NULLABILITY_NULLABLE))
+    assert evaluate("i16?") == Type(i16=Type.I16(nullability=Type.NULLABILITY_NULLABLE))
+    assert evaluate("i32?") == Type(i32=Type.I32(nullability=Type.NULLABILITY_NULLABLE))
+    assert evaluate("i64?") == Type(i64=Type.I64(nullability=Type.NULLABILITY_NULLABLE))
+    assert evaluate("fp32?") == Type(
+        fp32=Type.FP32(nullability=Type.NULLABILITY_NULLABLE)
+    )
+    assert evaluate("fp64?") == Type(
+        fp64=Type.FP64(nullability=Type.NULLABILITY_NULLABLE)
+    )
+    assert evaluate("boolean?") == Type(
+        bool=Type.Boolean(nullability=Type.NULLABILITY_NULLABLE)
+    )
 
 
 def test_data_type():
     assert evaluate("decimal<P + 1, S + 1>", {"S": 10, "P": 20}) == Type(
-        decimal=Type.Decimal(precision=21, scale=11)
+        decimal=Type.Decimal(
+            precision=21, scale=11, nullability=Type.NULLABILITY_REQUIRED
+        )
+    )
+
+
+def test_data_type_nullable():
+    assert evaluate("decimal?<P + 1, S + 1>", {"S": 10, "P": 20}) == Type(
+        decimal=Type.Decimal(
+            precision=21, scale=11, nullability=Type.NULLABILITY_NULLABLE
+        )
     )
 
 
@@ -59,7 +89,11 @@ def test_decimal_example():
         prec = min(init_prec, 38)
         scale_after_borrow = max(init_scale - delta, min_scale)
         scale = scale_after_borrow if init_prec > 38 else init_scale
-        return Type(decimal=Type.Decimal(precision=prec, scale=scale))
+        return Type(
+            decimal=Type.Decimal(
+                precision=prec, scale=scale, nullability=Type.NULLABILITY_REQUIRED
+            )
+        )
 
     args = {"P1": 10, "S1": 8, "P2": 14, "S2": 2}
 

--- a/tests/test_function_registry.py
+++ b/tests/test_function_registry.py
@@ -1,0 +1,220 @@
+import yaml
+
+from substrait.gen.proto.type_pb2 import Type
+from substrait.function_registry import FunctionRegistry
+
+content = """%YAML 1.2
+---
+scalar_functions:
+  - name: "test_fn"
+    description: ""
+    impls:
+      - args:
+          - value: i8
+        variadic:
+          min: 2
+        return: i8
+  - name: "test_fn_variadic_any"
+    description: ""
+    impls:
+      - args:
+          - value: any1
+        variadic:
+          min: 2
+        return: any1
+  - name: "add"
+    description: "Add two values."
+    impls:
+      - args:
+          - name: x
+            value: i8
+          - name: y
+            value: i8
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+        return: i8
+      - args:
+          - name: x
+            value: i8
+          - name: y
+            value: i8
+          - name: z
+            value: any
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+        return: i16
+      - args:
+          - name: x
+            value: any1
+          - name: y
+            value: any1
+          - name: z
+            value: any2
+        options:
+          overflow:
+            values: [ SILENT, SATURATE, ERROR ]
+        return: any2
+  - name: "test_decimal"
+    impls:
+      - args:
+          - name: x
+            value: decimal<P1,S1>
+          - name: y
+            value: decimal<S1,S2>
+        return: decimal<P1 + 1,S2 + 1>
+  - name: "test_enum"
+    impls:
+      - args:
+          - name: op
+            options: [ INTACT, FLIP ]
+          - name: x
+            value: i8
+        return: i8
+
+"""
+
+
+registry = FunctionRegistry()
+
+registry.register_extension_dict(yaml.safe_load(content), uri="test")
+
+
+def i8():
+    return Type(i8=Type.I8())
+
+
+def i16():
+    return Type(i16=Type.I16())
+
+
+def bool():
+    return Type(bool=Type.Boolean())
+
+
+def decimal(precision, scale):
+    return Type(decimal=Type.Decimal(scale=scale, precision=precision))
+
+
+def test_non_existing_uri():
+    assert (
+        registry.lookup_function(
+            uri="non_existent", function_name="add", signature=[i8(), i8()]
+        )
+        is None
+    )
+
+
+def test_non_existing_function():
+    assert (
+        registry.lookup_function(
+            uri="test", function_name="sub", signature=[i8(), i8()]
+        )
+        is None
+    )
+
+
+def test_non_existing_function_signature():
+    assert (
+        registry.lookup_function(uri="test", function_name="add", signature=[i8()])
+        is None
+    )
+
+
+def test_exact_match():
+    assert registry.lookup_function(
+        uri="test", function_name="add", signature=[i8(), i8()]
+    )[1] == Type(i8=Type.I8())
+
+
+def test_wildcard_match():
+    assert registry.lookup_function(
+        uri="test", function_name="add", signature=[i8(), i8(), bool()]
+    )[1] == Type(i16=Type.I16())
+
+
+def test_wildcard_match_fails_with_constraits():
+    assert (
+        registry.lookup_function(
+            uri="test", function_name="add", signature=[i8(), i16(), i16()]
+        )
+        is None
+    )
+
+
+def test_wildcard_match_with_constraits():
+    assert (
+        registry.lookup_function(
+            uri="test", function_name="add", signature=[i16(), i16(), i8()]
+        )[1]
+        == i8()
+    )
+
+
+def test_variadic():
+    assert (
+        registry.lookup_function(
+            uri="test", function_name="test_fn", signature=[i8(), i8(), i8()]
+        )[1]
+        == i8()
+    )
+
+
+def test_variadic_any():
+    assert (
+        registry.lookup_function(
+            uri="test",
+            function_name="test_fn_variadic_any",
+            signature=[i16(), i16(), i16()],
+        )[1]
+        == i16()
+    )
+
+
+def test_variadic_fails_min_constraint():
+    assert (
+        registry.lookup_function(uri="test", function_name="test_fn", signature=[i8()])
+        is None
+    )
+
+
+def test_decimal_happy_path():
+    assert registry.lookup_function(
+        uri="test",
+        function_name="test_decimal",
+        signature=[decimal(10, 8), decimal(8, 6)],
+    )[1] == decimal(11, 7)
+
+
+def test_decimal_violates_constraint():
+    assert (
+        registry.lookup_function(
+            uri="test",
+            function_name="test_decimal",
+            signature=[decimal(10, 8), decimal(12, 10)],
+        )
+        is None
+    )
+
+
+def test_enum_with_valid_option():
+    assert (
+        registry.lookup_function(
+            uri="test",
+            function_name="test_enum",
+            signature=["FLIP", i8()],
+        )[1]
+        == i8()
+    )
+
+
+def test_enum_with_nonexistent_option():
+    assert (
+        registry.lookup_function(
+            uri="test",
+            function_name="test_enum",
+            signature=["NONEXISTENT", i8()],
+        )
+        is None
+    )


### PR DESCRIPTION
adds FunctionRegistry that handles lookup and type inference of extension functions.
uses derivation expressions under the hood to generate return types.
pyyaml is now part of `extensions` extra.