### PR TITLE
chore: drop support for python 3.8

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.10-buster
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.9-buster
 USER vscode
 RUN curl -s "https://get.sdkman.io" | bash
 SHELL ["/bin/bash", "-c"]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python: ["3.8", "3.9", "3.10", "3.11"]
+        python: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ description = "A python package for Substrait."
 authors = [{name = "Substrait contributors", email = "substrait@googlegroups.com"}]
 license = {text = "Apache-2.0"}
 readme = "README.md"
-requires-python = ">=3.8.1"
+requires-python = ">=3.9"
 dependencies = ["protobuf >= 3.20"]
 dynamic = ["version"]
 
@@ -27,7 +27,7 @@ build-backend = "setuptools.build_meta"
 [tool.ruff]
 respect-gitignore = true
 # should target minimum supported version
-target-version = "py38"
+target-version = "py39"
 # never autoformat upstream or generated code
 exclude = ["third_party/", "src/substrait/gen"]
 # do not autofix the following (will still get flagged in lint)


### PR DESCRIPTION
drops support for python 3.8 that already reached EOL.
adds py312 and py313 to ci instead.