### PR TITLE
feat: add builders for switch, cast expressions

### DIFF
--- a/examples/pyarrow_example.py
+++ b/examples/pyarrow_example.py
@@ -1,0 +1,31 @@
+# Install pyarrow before running this example
+# /// script
+# dependencies = [
+#   "pyarrow==20.0.0",
+#   "substrait[extensions] @ file:///${PROJECT_ROOT}/"
+# ]
+# ///
+import pyarrow as pa
+import pyarrow.compute as pc
+import pyarrow.substrait as pa_substrait
+import substrait
+from substrait.builders.plan import project, read_named_table
+
+arrow_schema = pa.schema([
+    pa.field("x", pa.int32()),
+    pa.field("y", pa.int32())
+])
+
+substrait_schema = pa_substrait.serialize_schema(arrow_schema).to_pysubstrait().base_schema
+
+substrait_expr = pa_substrait.serialize_expressions(
+    exprs=[pc.field("x") + pc.field("y")],
+    names=["total"],
+    schema=arrow_schema
+)
+
+pysubstrait_expr = substrait.proto.ExtendedExpression.FromString(bytes(substrait_expr))
+
+table = read_named_table("example", substrait_schema)
+table = project(table, expressions=[pysubstrait_expr])(None)
+print(table)

--- a/tests/builders/extended_expression/test_aggregate_function.py
+++ b/tests/builders/extended_expression/test_aggregate_function.py
@@ -39,8 +39,8 @@ registry = ExtensionRegistry(load_default_extensions=False)
 registry.register_extension_dict(yaml.safe_load(content), uri="test_uri")
 
 def test_aggregate_count():
-    e = aggregate_function('test_uri', 'count', 
-                           literal(10, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED))),
+    e = aggregate_function('test_uri', 'count',
+                           expressions=[literal(10, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)))],
                            alias='count',
                            )(named_struct, registry)
     

--- a/tests/builders/extended_expression/test_cast.py
+++ b/tests/builders/extended_expression/test_cast.py
@@ -1,0 +1,49 @@
+import yaml
+
+import substrait.gen.proto.algebra_pb2 as stalg
+import substrait.gen.proto.type_pb2 as stt
+import substrait.gen.proto.extended_expression_pb2 as stee
+from substrait.builders.extended_expression import cast, literal
+from substrait.builders.type import i8, i16
+from substrait.extension_registry import ExtensionRegistry
+
+struct = stt.Type.Struct(
+    types=[
+        stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+        stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ]
+)
+
+named_struct = stt.NamedStruct(
+    names=["order_id", "description", "order_total"], struct=struct
+)
+
+registry = ExtensionRegistry(load_default_extensions=False)
+
+def test_cast():
+    e = cast(
+        input=literal(3, i8()),
+        type=i16()
+    )(named_struct, registry)
+    
+    expected = stee.ExtendedExpression(
+        referred_expr=[
+            stee.ExpressionReference(
+                expression=stalg.Expression(
+                    cast=stalg.Expression.Cast(
+                        type=stt.Type(
+                            i16=stt.Type.I16(nullability=stt.Type.NULLABILITY_NULLABLE)
+                        ),
+                        input=stalg.Expression(literal=stalg.Expression.Literal(i8=3, nullable=True)),
+                        failure_behavior=stalg.Expression.Cast.FAILURE_BEHAVIOR_RETURN_NULL
+                    )
+                ),
+                output_names=["cast"],
+            )
+        ],
+        base_schema=named_struct,
+    )
+
+    assert e == expected
+

--- a/tests/builders/extended_expression/test_multi_or_list.py
+++ b/tests/builders/extended_expression/test_multi_or_list.py
@@ -1,0 +1,65 @@
+import yaml
+
+import substrait.gen.proto.algebra_pb2 as stalg
+import substrait.gen.proto.type_pb2 as stt
+import substrait.gen.proto.extended_expression_pb2 as stee
+from substrait.builders.extended_expression import multi_or_list, literal
+from substrait.builders.type import i8
+from substrait.extension_registry import ExtensionRegistry
+
+struct = stt.Type.Struct(
+    types=[
+        stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+        stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ]
+)
+
+named_struct = stt.NamedStruct(
+    names=["order_id", "description", "order_total"], struct=struct
+)
+
+registry = ExtensionRegistry(load_default_extensions=False)
+
+def test_singular_or_list():
+    e = multi_or_list(
+        value=[literal(1, i8()), literal(2, i8())],
+        options=[
+            [literal(1, i8()), literal(2, i8())],
+            [literal(3, i8()), literal(4, i8())]
+        ]
+    )(named_struct, registry)
+    
+    expected = stee.ExtendedExpression(
+        referred_expr=[
+            stee.ExpressionReference(
+                expression=stalg.Expression(
+                    multi_or_list=stalg.Expression.MultiOrList(
+                        value=[
+                            stalg.Expression(literal=stalg.Expression.Literal(i8=1, nullable=True)),
+                            stalg.Expression(literal=stalg.Expression.Literal(i8=2, nullable=True))
+                        ],
+                        options=[
+                            stalg.Expression.MultiOrList.Record(
+                                fields=[
+                                    stalg.Expression(literal=stalg.Expression.Literal(i8=1, nullable=True)),
+                                    stalg.Expression(literal=stalg.Expression.Literal(i8=2, nullable=True))
+                                ]
+                            ),
+                            stalg.Expression.MultiOrList.Record(
+                                fields=[
+                                    stalg.Expression(literal=stalg.Expression.Literal(i8=3, nullable=True)),
+                                    stalg.Expression(literal=stalg.Expression.Literal(i8=4, nullable=True))
+                                ]
+                            )
+                        ]
+                    )
+                ),
+                output_names=["multi_or_list"],
+            )
+        ],
+        base_schema=named_struct,
+    )
+
+    assert e == expected
+

--- a/tests/builders/extended_expression/test_scalar_function.py
+++ b/tests/builders/extended_expression/test_scalar_function.py
@@ -44,9 +44,10 @@ registry.register_extension_dict(yaml.safe_load(content), uri="test_uri")
 
 def test_sclar_add():
     e = scalar_function('test_uri', 'test_func', 
-                           literal(10, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED))), 
-                           literal(20, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)))
-                           )(named_struct, registry)
+                        expressions=[
+                            literal(10, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED))), 
+                            literal(20, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)))
+                        ])(named_struct, registry)
     
     expected = stee.ExtendedExpression(
         extension_uris=[
@@ -87,9 +88,14 @@ def test_sclar_add():
 
 def test_nested_scalar_calls():
     e = scalar_function('test_uri', 'is_positive',
-            scalar_function('test_uri', 'test_func', 
+            expressions=[
+                scalar_function('test_uri', 'test_func',
+                    expressions=[
                         literal(10, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED))), 
-                        literal(20, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)))),
+                        literal(20, type=stt.Type(i8=stt.Type.I8(nullability=stt.Type.NULLABILITY_REQUIRED)))
+                    ]
+                )
+            ],
             alias='positive'
         )(named_struct, registry)
     

--- a/tests/builders/extended_expression/test_singular_or_list.py
+++ b/tests/builders/extended_expression/test_singular_or_list.py
@@ -1,0 +1,52 @@
+import yaml
+
+import substrait.gen.proto.algebra_pb2 as stalg
+import substrait.gen.proto.type_pb2 as stt
+import substrait.gen.proto.extended_expression_pb2 as stee
+from substrait.builders.extended_expression import singular_or_list, literal
+from substrait.builders.type import i8
+from substrait.extension_registry import ExtensionRegistry
+
+struct = stt.Type.Struct(
+    types=[
+        stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+        stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ]
+)
+
+named_struct = stt.NamedStruct(
+    names=["order_id", "description", "order_total"], struct=struct
+)
+
+registry = ExtensionRegistry(load_default_extensions=False)
+
+def test_singular_or_list():
+    e = singular_or_list(
+        value=literal(3, i8()),
+        options=[
+            literal(1, i8()),
+            literal(2, i8())
+        ]
+    )(named_struct, registry)
+    
+    expected = stee.ExtendedExpression(
+        referred_expr=[
+            stee.ExpressionReference(
+                expression=stalg.Expression(
+                    singular_or_list=stalg.Expression.SingularOrList(
+                        value=stalg.Expression(literal=stalg.Expression.Literal(i8=3, nullable=True)),
+                        options=[
+                            stalg.Expression(literal=stalg.Expression.Literal(i8=1, nullable=True)),
+                            stalg.Expression(literal=stalg.Expression.Literal(i8=2, nullable=True))
+                        ]
+                    )
+                ),
+                output_names=["singular_or_list"],
+            )
+        ],
+        base_schema=named_struct,
+    )
+
+    assert e == expected
+

--- a/tests/builders/extended_expression/test_switch.py
+++ b/tests/builders/extended_expression/test_switch.py
@@ -1,0 +1,62 @@
+import yaml
+
+import substrait.gen.proto.algebra_pb2 as stalg
+import substrait.gen.proto.type_pb2 as stt
+import substrait.gen.proto.extended_expression_pb2 as stee
+from substrait.builders.extended_expression import switch, literal
+from substrait.builders.type import i8
+from substrait.extension_registry import ExtensionRegistry
+
+struct = stt.Type.Struct(
+    types=[
+        stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        stt.Type(string=stt.Type.String(nullability=stt.Type.NULLABILITY_NULLABLE)),
+        stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+    ]
+)
+
+named_struct = stt.NamedStruct(
+    names=["order_id", "description", "order_total"], struct=struct
+)
+
+registry = ExtensionRegistry(load_default_extensions=False)
+
+def test_switch():
+    e = switch(
+        match=literal(3, i8()),
+        ifs=[
+            (literal(1, i8()), literal(1, i8())),
+            (literal(2, i8()), literal(4, i8()))
+        ],
+        _else=literal(9, i8())
+    )(named_struct, registry)
+    
+    expected = stee.ExtendedExpression(
+        referred_expr=[
+            stee.ExpressionReference(
+                expression=stalg.Expression(
+                    switch_expression=stalg.Expression.SwitchExpression(
+                        match=stalg.Expression(literal=stalg.Expression.Literal(i8=3, nullable=True)),
+                        ifs=[
+                            stalg.Expression.SwitchExpression.IfValue(**{
+                                'if': stalg.Expression.Literal(i8=1, nullable=True),
+                                'then': stalg.Expression(literal=stalg.Expression.Literal(i8=1, nullable=True))
+                            }),
+                            stalg.Expression.SwitchExpression.IfValue(**{
+                                'if': stalg.Expression.Literal(i8=2, nullable=True),
+                                'then': stalg.Expression(literal=stalg.Expression.Literal(i8=4, nullable=True))
+                            }),
+                        ],
+                        **{
+                            'else': stalg.Expression(literal=stalg.Expression.Literal(i8=9, nullable=True))
+                        }
+                    )
+                ),
+                output_names=["switch"],
+            )
+        ],
+        base_schema=named_struct,
+    )
+
+    assert e == expected
+

--- a/tests/builders/extended_expression/test_window_function.py
+++ b/tests/builders/extended_expression/test_window_function.py
@@ -45,7 +45,7 @@ registry = ExtensionRegistry(load_default_extensions=False)
 registry.register_extension_dict(yaml.safe_load(content), uri="test_uri")
 
 def test_row_number():
-    e = window_function('test_uri', 'row_number', alias='rn')(named_struct, registry)
+    e = window_function('test_uri', 'row_number', expressions=[], alias='rn')(named_struct, registry)
     
     expected = stee.ExtendedExpression(
         extension_uris=[

--- a/tests/builders/plan/test_aggregate.py
+++ b/tests/builders/plan/test_aggregate.py
@@ -38,7 +38,7 @@ def test_aggregate():
     table = read_named_table('table', named_struct)
 
     group_expr = column('id')
-    measure_expr = aggregate_function('test_uri', 'count', column('is_applicable'), alias=['count'])
+    measure_expr = aggregate_function('test_uri', 'count', expressions=[column('is_applicable')], alias=['count'])
 
     actual = aggregate(table, 
                        grouping_expressions=[group_expr],


### PR DESCRIPTION
- Builders for switch, cast, singular_or_list, multi_or_list
- Builders accept either `ExtendedExtension` or `UnboundExtendedExtension`
- Adds example of using pyarrow expressions to build substrait plans