### PR TITLE
chore: fix and update devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,13 +1,13 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.9-buster
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.13
 USER vscode
 RUN curl -s "https://get.sdkman.io" | bash
 SHELL ["/bin/bash", "-c"]
-RUN source "/home/vscode/.sdkman/bin/sdkman-init.sh" && sdk install java 20.0.2-graalce
-RUN mkdir -p ~/lib && cd ~/lib && curl -L -O http://www.antlr.org/download/antlr-4.13.1-complete.jar
+RUN source "/home/vscode/.sdkman/bin/sdkman-init.sh" && sdk install java 25-graalce
+RUN mkdir -p ~/lib && cd ~/lib && curl -L -O http://www.antlr.org/download/antlr-4.13.2-complete.jar
 ENV ANTLR_JAR="~/lib/antlr-4.13.1-complete.jar"
-RUN cd ~ && curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v25.1/protoc-25.1-linux-x86_64.zip && \
-    unzip protoc-25.1-linux-x86_64.zip -d ~/.local && \
-    rm protoc-25.1-linux-x86_64.zip
-RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.50.0/buf-$(uname -s)-$(uname -m)" -o ~/.local/bin/buf && chmod +x ~/.local/bin/buf
-RUN curl -LsSf https://astral.sh/uv/0.7.11/install.sh | sh
+RUN cd ~ && curl -LO https://github.com/protocolbuffers/protobuf/releases/download/v30.2/protoc-30.2-linux-x86_64.zip && \
+    unzip protoc-30.2-linux-x86_64.zip -d ~/.local && \
+    rm protoc-30.2-linux-x86_64.zip
+RUN curl -sSL "https://github.com/bufbuild/buf/releases/download/v1.58.0/buf-$(uname -s)-$(uname -m)" -o ~/.local/bin/buf && chmod +x ~/.local/bin/buf
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 USER root

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,7 +2,8 @@
 	"name": "substrait-python-devcontainer",
 	"build": {
 		"context": "..",
-		"dockerfile": "Dockerfile"
+		"dockerfile": "Dockerfile",
+		"options": ["--format=docker"]
 	},
 
 	// Features to add to the dev container. More info: https://containers.dev/features.
@@ -14,10 +15,21 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "poetry install"
+	"postCreateCommand": "uv venv --clear && uv sync --extra test",
 
 	// Configure tool-specific properties.
-	// "customizations": {},
+	"customizations": {
+		"vscode": {
+			"settings": {
+				"python.testing.pytestArgs": [
+					"tests"
+				],
+				"python.testing.unittestEnabled": false,
+				"python.testing.pytestEnabled": true
+			},
+			"extensions": []
+		}
+	}
 
 	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
 	// "remoteUser": "root"


### PR DESCRIPTION
this PR fixes and updates the VS Code devcontainer:
- fix: the previous image `mcr.microsoft.com/vscode/devcontainers/python:3.9-buster` was dropped 
  by Microsoft so switching to a version without specifying the Debian base version and upgrading 
  to Python 3.13
- updates Graal to 25
- updates ANTLR to 4.13.2
- updates protoc to 30.2
- updates buf to 1.58.0
- updates uv to the latest version
- adds the --format=docker build option which makes the SHELL dockerfile instruction work with 
  podman
- adds a `postCreateCommand` that creates a virtualenv and install the dependencies into it
- adds some VS Code settings for pytest integration