### PR TITLE
fix: use version from src/substrait/__init__.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,15 +53,9 @@ update-substrait = [ { task = "update-submodule" }, { task = "codegen" }]
 
 update-submodule = "./update_submodule.sh"
 
-codegen = [{ task = "antlr" }, { task = "codegen-proto" }, { task = "codegen-extensions" }, { task = "codegen-version" }]
+codegen = [{ task = "antlr" }, { task = "codegen-proto" }, { task = "codegen-extensions" }]
 
 check-codegen = "./check_codegen.sh"
-
-codegen-version = """bash -c '
-cd third_party/substrait
-export version=$(git describe --tags | tr -d 'v')
-echo "substrait_version = \\"$version\\"" > ../../src/substrait/gen/version.py
-'"""
 
 codegen-proto = "./gen_proto.sh"
 

--- a/src/substrait/builders/plan.py
+++ b/src/substrait/builders/plan.py
@@ -12,13 +12,13 @@ import substrait.gen.proto.algebra_pb2 as stalg
 import substrait.gen.proto.extended_expression_pb2 as stee
 import substrait.gen.proto.plan_pb2 as stp
 import substrait.gen.proto.type_pb2 as stt
+from substrait import __substrait_version__
 from substrait.builders.extended_expression import (
     ExtendedExpressionOrUnbound,
     resolve_expression,
 )
 from substrait.extension_registry import ExtensionRegistry
 from substrait.gen.proto.extensions.extensions_pb2 import AdvancedExtension
-from substrait.gen.version import substrait_version
 from substrait.type_inference import infer_plan_schema
 from substrait.utils import (
     merge_extension_declarations,
@@ -33,7 +33,7 @@ PlanOrUnbound = Union[stp.Plan, UnboundPlan]
 
 def _create_default_version():
     p = re.compile(r"(\d+)\.(\d+)\.(\d+)")
-    m = p.match(substrait_version)
+    m = p.match(__substrait_version__)
     global default_version
     default_version = stp.Version(
         major_number=int(m.group(1)),

--- a/src/substrait/gen/version.py
+++ b/src/substrait/gen/version.py
@@ -1,1 +1,0 @@
-substrait_version = "0.77.0"


### PR DESCRIPTION
I realized while looking at #142 that there is already a substrait version 
variable defined in `src/substrait/__init__.py` which gets updated when 
the Git submodule is updated and we don't need the one in 
`src/substrait/gen/version.py`.