### PR TITLE
test: fix consistent partition window test for urn-based extension API

### DIFF
--- a/tests/builders/plan/test_consistent_partition_window.py
+++ b/tests/builders/plan/test_consistent_partition_window.py
@@ -54,9 +54,7 @@ window_functions:
 """
 
 registry = ExtensionRegistry(load_default_extensions=False)
-registry.register_extension_dict(
-    yaml.safe_load(content), uri="https://test.example.com/test.yaml"
-)
+registry.register_extension_dict(yaml.safe_load(content))
 
 struct = stt.Type.Struct(
     types=[i64(nullable=False), i16(nullable=False), i32(nullable=False)],
@@ -106,7 +104,6 @@ def test_consistent_partition_window_single():
     expected = stp.Plan(
         version=default_version,
         extension_urns=list(lead_ee.extension_urns),
-        extension_uris=list(lead_ee.extension_uris),
         extensions=list(lead_ee.extensions),
         relations=[
             stp.PlanRel(


### PR DESCRIPTION
## Summary

The `main` CI is red because test collection fails on
`tests/builders/plan/test_consistent_partition_window.py`, which cancels the
whole test matrix.

The test (added in #158) was written against the older `uri`-based extension
API, but the codebase has since migrated to `urn`s. Two stale references
remained:

- `register_extension_dict(..., uri=...)`: the `uri` keyword no longer exists,
  causing a `TypeError` at collection time. The URN is now supplied via the
  `urn:` field already present in the test's YAML, so the kwarg is removed.
- `extension_uris=list(lead_ee.extension_uris)`: this proto field was renamed to
  `extension_urns` (already present on the preceding line). This second error
  was masked by the collection failure.

## Test plan

- `pytest tests/builders/plan/test_consistent_partition_window.py` -> 8 passed
- Full suite -> 231 passed, 3 xfailed