### PR TITLE
ci: upgrade to node 24

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v6
         with:
-          node-version: "18"
+          node-version: "24"
       - run: npm install @commitlint/config-conventional
       - run: >
           echo 'module.exports = {


### PR DESCRIPTION
We currently get warnings during the PR build since `commitlint` requires Node >= 20. 
This PR upgrades node to the latest LTS release 24 for the commitlint GH action task.

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'global-directory@5.0.0',
npm warn EBADENGINE   required: { node: '>=20' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'ini@6.0.0',
npm warn EBADENGINE   required: { node: '^20.17.0 || >=22.9.0' },
npm warn EBADENGINE   current: { node: 'v18.20.8', npm: '10.8.2' }
npm warn EBADENGINE }

```

https://github.com/substrait-io/substrait-python/actions/runs/26420357425/job/77773667715?pr=165#step:5:75