### PR TITLE
feat: bump substrait packages to 0.86.0 and support additional extension metadata

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -35,8 +35,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_6.conda
       - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
@@ -63,8 +63,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/zstd-1.5.7-h85ac4a6_6.conda
       - pypi: https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -84,8 +84,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -104,8 +104,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
@@ -126,8 +126,8 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - pypi: https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -176,9 +176,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f9/04/98c216967275cd9a3e517dfeeb513ebff3183f1f22da29180c479c749ac8/sqloxide-0.1.56-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
@@ -218,9 +218,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/de/77/dd27f6e325537126ba0b142fdce63bde4305681662ac58e8e779e3c87635/sqloxide-0.1.56-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -253,9 +253,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/10/c7/79f57728f300079148ac4e4b988000dcbd1f58960040db89594424a58336/sqloxide-0.1.56.tar.gz
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -287,9 +287,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/94/fd/268d58f8feb4d206d2896dae5e8a4a17c671c9cbb6b15c6e6300d2e168a2/sqloxide-0.1.56-cp313-cp313-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
@@ -324,9 +324,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c8/5c/487e081a5ac1a8538f7eb3a3e3ea04c39da13acde1f17916ca1767d40c4e/sqloxide-0.1.56-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
   extensions:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -364,9 +364,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
@@ -395,9 +395,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -419,9 +419,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -442,9 +442,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
@@ -467,9 +467,9 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
   sql:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -508,8 +508,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/f9/04/98c216967275cd9a3e517dfeeb513ebff3183f1f22da29180c479c749ac8/sqloxide-0.1.56-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
@@ -539,8 +539,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/de/77/dd27f6e325537126ba0b142fdce63bde4305681662ac58e8e779e3c87635/sqloxide-0.1.56-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h500dc9f_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -563,8 +563,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/10/c7/79f57728f300079148ac4e4b988000dcbd1f58960040db89594424a58336/sqloxide-0.1.56.tar.gz
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-hd037594_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -586,8 +586,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
       - pypi: https://files.pythonhosted.org/packages/94/fd/268d58f8feb4d206d2896dae5e8a4a17c671c9cbb6b15c6e6300d2e168a2/sqloxide-0.1.56-cp313-cp313-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/win-64/bzip2-1.0.8-h0ad9c76_8.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
@@ -611,8 +611,8 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/c8/5c/487e081a5ac1a8538f7eb3a3e3ea04c39da13acde1f17916ca1767d40c4e/sqloxide-0.1.56-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -1834,22 +1834,22 @@ packages:
   version: 0.1.56
   sha256: 5e94f9037d7336bef4e3090b15299c2a405c55aba4ae87ef6d963df2f0b48016
   requires_python: '>=3.7'
-- pypi: https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl
   name: substrait-antlr
-  version: 0.85.0
-  sha256: f46cbfb15117aab77fd48d8e9a531fa0f79e82b4c20a54a174a97f4511d96396
+  version: 0.86.0
+  sha256: ed6eae9a6b9628c93f4a82ff5734add586e3124f924e255b75360e4dafb31146
   requires_dist:
   - antlr4-python3-runtime>=4.13,<5
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl
   name: substrait-extensions
-  version: 0.85.0
-  sha256: 4ad8b84411020f75c74e987719bbdaa19d1947ffb3c91b3c707418a0a821b424
+  version: 0.86.0
+  sha256: b4c637137f74d5cffc0e28259cd94ddb6e76b5e970b06ab0b4f84f68bed2ef82
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl
+- pypi: https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl
   name: substrait-protobuf
-  version: 0.85.0
-  sha256: aff4cb74a0dbab35be11d373fc381d53957f2e97d17158c2c3ce68cdf57498e8
+  version: 0.86.0
+  sha256: 88548334a77dfdded43025c2dd7d4c85a449e72d7e74e92b270381c31b007619
   requires_dist:
   - protobuf>=5,<7
   requires_python: '>=3.10'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "protobuf >=5,<7",
-    "substrait-protobuf==0.85.0",
-    "substrait-extensions==0.85.0",
+    "substrait-protobuf==0.86.0",
+    "substrait-extensions==0.86.0",
 ]
 dynamic = ["version"]
 
@@ -16,11 +16,11 @@ dynamic = ["version"]
 write_to = "src/substrait/_version.py"
 
 [project.optional-dependencies]
-extensions = ["antlr4-python3-runtime", "substrait-antlr==0.85.0", "pyyaml"]
+extensions = ["antlr4-python3-runtime", "substrait-antlr==0.86.0", "pyyaml"]
 sql = ["sqloxide; python_version < '3.14'", "deepdiff"]
 
 [dependency-groups]
-dev = ["pytest >= 7.0.0", "antlr4-python3-runtime", "substrait-antlr==0.85.0", "pyyaml", "sqloxide; python_version < '3.14'", "deepdiff", "duckdb<=1.2.2; python_version < '3.14'", "datafusion"]
+dev = ["pytest >= 7.0.0", "antlr4-python3-runtime", "substrait-antlr==0.86.0", "pyyaml", "sqloxide; python_version < '3.14'", "deepdiff", "duckdb<=1.2.2; python_version < '3.14'", "datafusion"]
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ dynamic = ["version"]
 write_to = "src/substrait/_version.py"
 
 [project.optional-dependencies]
-extensions = ["antlr4-python3-runtime", "substrait-antlr==0.86.0", "pyyaml"]
+extensions = ["substrait-antlr==0.86.0", "pyyaml"]
 sql = ["sqloxide; python_version < '3.14'", "deepdiff"]
 
 [dependency-groups]
-dev = ["pytest >= 7.0.0", "antlr4-python3-runtime", "substrait-antlr==0.86.0", "pyyaml", "sqloxide; python_version < '3.14'", "deepdiff", "duckdb<=1.2.2; python_version < '3.14'", "datafusion"]
+dev = ["pytest >= 7.0.0", "substrait-antlr==0.86.0", "pyyaml", "sqloxide; python_version < '3.14'", "deepdiff", "duckdb<=1.2.2; python_version < '3.14'", "datafusion"]
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/src/substrait/simple_extension_utils.py
+++ b/src/substrait/simple_extension_utils.py
@@ -1,6 +1,16 @@
-from typing import Union
+from typing import Optional, Union
 
 from substrait_extensions.extensions import simple_extensions as se
+
+
+def build_deprecation_status(d: Optional[dict]) -> Optional[se.DeprecationStatus]:
+    if d is None:
+        return None
+    return se.DeprecationStatus(
+        since=d["since"],
+        reason=d.get("reason"),
+        metadata=d.get("metadata"),
+    )
 
 
 def build_arg(d: dict) -> Union[se.ValueArg, se.TypeArg, se.EnumerationArg]:
@@ -44,6 +54,8 @@ def build_scalar_function(d: dict) -> se.ScalarFunction:
         impls=[
             se.Impl(
                 return_=i["return"],
+                deprecated=build_deprecation_status(i.get("deprecated")),
+                description=i.get("description"),
                 args=[build_arg(arg) for arg in i["args"]] if "args" in i else None,
                 options=build_options(i["options"]) if "options" in i else None,
                 variadic=build_variadic_behavior(i["variadic"])
@@ -58,7 +70,9 @@ def build_scalar_function(d: dict) -> se.ScalarFunction:
             )
             for i in d["impls"]
         ],
+        deprecated=build_deprecation_status(d.get("deprecated")),
         description=d.get("description"),
+        metadata=d.get("metadata"),
     )
 
 
@@ -68,6 +82,8 @@ def build_aggregate_function(d: dict) -> se.AggregateFunction:
         impls=[
             se.Impl1(
                 return_=i["return"],
+                deprecated=build_deprecation_status(i.get("deprecated")),
+                description=i.get("description"),
                 args=[build_arg(arg) for arg in i["args"]] if "args" in i else None,
                 options=build_options(i["options"]) if "options" in i else None,
                 variadic=build_variadic_behavior(i["variadic"])
@@ -88,7 +104,9 @@ def build_aggregate_function(d: dict) -> se.AggregateFunction:
             )
             for i in d["impls"]
         ],
+        deprecated=build_deprecation_status(d.get("deprecated")),
         description=d.get("description"),
+        metadata=d.get("metadata"),
     )
 
 
@@ -98,6 +116,8 @@ def build_window_function(d: dict) -> se.WindowFunction:
         impls=[
             se.Impl2(
                 return_=i["return"],
+                deprecated=build_deprecation_status(i.get("deprecated")),
+                description=i.get("description"),
                 args=[build_arg(arg) for arg in i["args"]] if "args" in i else None,
                 options=build_options(i["options"]) if "options" in i else None,
                 variadic=build_variadic_behavior(i["variadic"])
@@ -121,13 +141,18 @@ def build_window_function(d: dict) -> se.WindowFunction:
             )
             for i in d["impls"]
         ],
+        deprecated=build_deprecation_status(d.get("deprecated")),
         description=d.get("description"),
+        metadata=d.get("metadata"),
     )
 
 
 def build_type_model(d: dict) -> se.TypeModel:
     return se.TypeModel(
         name=d["name"],
+        deprecated=build_deprecation_status(d.get("deprecated")),
+        description=d.get("description"),
+        metadata=d.get("metadata"),
         structure=d.get("structure"),
         parameters=d.get("parameters"),
         variadic=d.get("variadic"),
@@ -138,6 +163,7 @@ def build_type_variation(d: dict) -> se.TypeVariation:
     return se.TypeVariation(
         parent=d["parent"],
         name=d["name"],
+        deprecated=build_deprecation_status(d.get("deprecated")),
         description=d.get("description"),
         functions=se.Functions(d["functions"]) if "functions" in d else None,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -371,9 +371,9 @@ requires-dist = [
     { name = "protobuf", specifier = ">=5,<7" },
     { name = "pyyaml", marker = "extra == 'extensions'" },
     { name = "sqloxide", marker = "python_full_version < '3.14' and extra == 'sql'" },
-    { name = "substrait-antlr", marker = "extra == 'extensions'", specifier = "==0.85.0" },
-    { name = "substrait-extensions", specifier = "==0.85.0" },
-    { name = "substrait-protobuf", specifier = "==0.85.0" },
+    { name = "substrait-antlr", marker = "extra == 'extensions'", specifier = "==0.86.0" },
+    { name = "substrait-extensions", specifier = "==0.86.0" },
+    { name = "substrait-protobuf", specifier = "==0.86.0" },
 ]
 provides-extras = ["extensions", "sql"]
 
@@ -386,40 +386,40 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pyyaml" },
     { name = "sqloxide", marker = "python_full_version < '3.14'" },
-    { name = "substrait-antlr", specifier = "==0.85.0" },
+    { name = "substrait-antlr", specifier = "==0.86.0" },
 ]
 
 [[package]]
 name = "substrait-antlr"
-version = "0.85.0"
+version = "0.86.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/d8/a48ab657b622d089e965aca98599b8f815285ef9771a0615ec35031b32d5/substrait_antlr-0.85.0.tar.gz", hash = "sha256:caf7197e065f9d50b51e8aca6607abd24219ce82dbf4e5a5f70eb711388436c2", size = 63471, upload-time = "2026-03-17T19:19:18.961Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/68/dfd2c282092e42799c0ececc41d94aa99a1a3b5da61913eaf918b17385b9/substrait_antlr-0.86.0.tar.gz", hash = "sha256:d907a72f7062beb57e75fe986d6ae001d604c3a213870b4077a9834d92a4566b", size = 63455, upload-time = "2026-04-14T12:34:58.23Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/f4/b7901b6db48f38c21ce512122e5f7f3b1bd3d66cec4de0d90fed62c0b994/substrait_antlr-0.85.0-py3-none-any.whl", hash = "sha256:f46cbfb15117aab77fd48d8e9a531fa0f79e82b4c20a54a174a97f4511d96396", size = 72954, upload-time = "2026-03-17T19:19:20.121Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a6/47d89f14837c958d57470b2f66b5265d261f5a9983c12793f6577a9411a5/substrait_antlr-0.86.0-py3-none-any.whl", hash = "sha256:ed6eae9a6b9628c93f4a82ff5734add586e3124f924e255b75360e4dafb31146", size = 72957, upload-time = "2026-04-14T12:34:58.949Z" },
 ]
 
 [[package]]
 name = "substrait-extensions"
-version = "0.85.0"
+version = "0.86.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/b2/eb2a7a8143d11ff25261ab1c8525386e4b2cbdcd9d282323fe97aac13165/substrait_extensions-0.85.0.tar.gz", hash = "sha256:6b5403b5e7d9cf5f9dbe86f276c6485c9155bec78fab080310202c99b177ca8a", size = 50866, upload-time = "2026-03-17T19:19:18.102Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/09/8618afea797b9e1d9c325f3aa43f78e98e45bd5f5ac9d55383349b002f54/substrait_extensions-0.86.0.tar.gz", hash = "sha256:4ec3d65f0a28ad1560dd887f3c9bb65a70072a8d17d77d985a3b44fdff38d218", size = 51250, upload-time = "2026-04-14T12:34:56.1Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/64/4a/36d734df05faa310b3ef0a492e47b85b6e082471473266bf355852f87bba/substrait_extensions-0.85.0-py3-none-any.whl", hash = "sha256:4ad8b84411020f75c74e987719bbdaa19d1947ffb3c91b3c707418a0a821b424", size = 105287, upload-time = "2026-03-17T19:19:19.042Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d0/448f1e6b24422d92eaf11176f26f685e939126c96f0f876485eaa7c79a19/substrait_extensions-0.86.0-py3-none-any.whl", hash = "sha256:b4c637137f74d5cffc0e28259cd94ddb6e76b5e970b06ab0b4f84f68bed2ef82", size = 105953, upload-time = "2026-04-14T12:34:54.715Z" },
 ]
 
 [[package]]
 name = "substrait-protobuf"
-version = "0.85.0"
+version = "0.86.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/df/36/de86485ada792ec97ffb6024efbfd701ddcbe93599dfffc895dd8f21f704/substrait_protobuf-0.85.0.tar.gz", hash = "sha256:e7776181dcb18703a6e27b0291de86c8034a02b5d92e1fc2fc919ced62757570", size = 59062, upload-time = "2026-03-17T19:19:14.018Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/55/e6dbe1db977a2a1d0c9db8d2cd82d38060f4d2ed293334d726dcb5651a06/substrait_protobuf-0.86.0.tar.gz", hash = "sha256:a0b9f5497a07fd11e7ca0fddbe923d09247d51d340bf551b749dde84eed1c85e", size = 59056, upload-time = "2026-04-14T12:34:50.717Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/68/db/20eba8a3cc5a78a53d1439d2067930b998bd842debac5b687a2a27a05dcc/substrait_protobuf-0.85.0-py3-none-any.whl", hash = "sha256:aff4cb74a0dbab35be11d373fc381d53957f2e97d17158c2c3ce68cdf57498e8", size = 64453, upload-time = "2026-03-17T19:19:15.084Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/6f/502e8543bd134c5fc5814453c4426d3c2ad64fe1d4c4c59cbfbad8cc6872/substrait_protobuf-0.86.0-py3-none-any.whl", hash = "sha256:88548334a77dfdded43025c2dd7d4c85a449e72d7e74e92b270381c31b007619", size = 64451, upload-time = "2026-04-14T12:34:49.671Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -343,7 +343,6 @@ dependencies = [
 
 [package.optional-dependencies]
 extensions = [
-    { name = "antlr4-python3-runtime" },
     { name = "pyyaml" },
     { name = "substrait-antlr" },
 ]
@@ -354,7 +353,6 @@ sql = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "antlr4-python3-runtime" },
     { name = "datafusion" },
     { name = "deepdiff" },
     { name = "duckdb", marker = "python_full_version < '3.14'" },
@@ -366,7 +364,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "antlr4-python3-runtime", marker = "extra == 'extensions'" },
     { name = "deepdiff", marker = "extra == 'sql'" },
     { name = "protobuf", specifier = ">=5,<7" },
     { name = "pyyaml", marker = "extra == 'extensions'" },
@@ -379,7 +376,6 @@ provides-extras = ["extensions", "sql"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "antlr4-python3-runtime" },
     { name = "datafusion" },
     { name = "deepdiff" },
     { name = "duckdb", marker = "python_full_version < '3.14'", specifier = "<=1.2.2" },


### PR DESCRIPTION
Bump `substrait-protobuf`, `substrait-extensions`, and `substrait-antlr` from 0.85.0 to 0.86.0.

Add support for the new 0.86.0 simple-extension schema fields when parsing extension YAML:

- deprecation status (`since`/`reason`/`metadata`) on types, type variations, functions, and
  individual implementations
- implementation-level `description`
- function- and type-level `metadata`

The 0.86.0 spec changes are otherwise contained in the vendored extension YAML shipped by the
packages (no proto changes), so no further code modifications were required.

All 231 tests pass (3 pre-existing xfails, unchanged from the 0.85.0 baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
