### PR TITLE
ci: remove PR title check comment when check passes

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -3,6 +3,10 @@ name: PR Title Check
 on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
 jobs:
   commitlint:
     name: PR title / description conforms to semantic-release
@@ -17,42 +21,60 @@ jobs:
             // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
             "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
           }' > .commitlintrc.js
-      - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
+      - id: commitlint
+        continue-on-error: true
+        run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
         env:
           COMMIT_MSG: >
             ${{ github.event.pull_request.title }}
 
             ${{ github.event.pull_request.body }}
-      - if: failure()
-        uses: actions/github-script@v9
+      - uses: actions/github-script@v9
         with:
           script: |
-            const message = `**ACTION NEEDED**
+            // Hidden marker used to find this job's comment regardless of wording.
+            const marker = "<!-- pr-title-check -->";
+            const message = `${marker}
+            **ACTION NEEDED**
 
-              Substrait follows the [Conventional Commits
-              specification](https://www.conventionalcommits.org/en/v1.0.0/) for
-              release automation.
+            Substrait follows the [Conventional Commits
+            specification](https://www.conventionalcommits.org/en/v1.0.0/) for
+            release automation.
 
-              The PR title and description are used as the merge commit message.\
-              Please update your PR title and description to match the specification.
-              `
-            // Get list of current comments
+            The PR title and description are used as the merge commit message.
+            Please update your PR title and description to match the specification.
+            `;
+            const passed = "${{ steps.commitlint.outcome }}" === "success";
+
+            // Find an existing comment from this job, if any.
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: context.issue.number
-            });
-            // Check if this job already commented
-            for (const comment of comments) {
-              if (comment.body === message) {
-                return // Already commented
-              }
-            }
-            // Post the comment about Conventional Commits
-            github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: message
-            })
-            core.setFailed(message)
+            });
+            const existing = comments.find((c) => c.body.includes(marker));
+
+            if (passed) {
+              // Clean up the comment now that the check passes.
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            // Check failed: post the comment if it isn't already there, then fail the job.
+            if (!existing) {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                body: message,
+              });
+            }
+            core.setFailed(
+              "PR title and description do not follow the Conventional Commits specification."
+            );


### PR DESCRIPTION
Ports https://github.com/substrait-io/substrait-java/pull/850 to substrait-python.

Previously the PR Title Check workflow posted an "ACTION NEEDED" comment when the PR
title/description did not follow Conventional Commits, but never removed it once the title was
fixed.

This consolidates the comment logic into a single `github-script` step that branches on the
commitlint outcome (using `continue-on-error: true` plus `core.setFailed(...)` to keep the check
red on failure):

- On pass: delete any previously posted comment.
- On fail: post the comment if not already present.

The bot comment is identified via a hidden `<!-- pr-title-check -->` marker rather than exact body
matching, so cleanup survives wording or whitespace changes. The workflow now declares
`permissions: pull-requests: write` so it can delete comments.

The Python-specific `.commitlintrc.js` content (the dependabot `Bumps [...]` ignore rule) is
preserved.

Note: cleanup is marker-based, so it only applies to comments posted by this new version going
forward. Pre-existing comments from the old workflow version won't be automatically removed.
