### PR TITLE
ci: align commitlint config with substrait-io/substrait

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -15,7 +15,15 @@ jobs:
       - run: >
           echo 'module.exports = {
             // Workaround for https://github.com/dependabot/dependabot-core/issues/5923
-            "ignores": [(message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message)]
+            "ignores": [
+              (message) => /^Bumps \[.+]\(.+\) from .+ to .+\.$/m.test(message),
+              (message) => /^Updates the requirements on .+ to permit the latest version\.$/m.test(message)
+            ],
+            "rules": {
+              "body-max-line-length": [0, "always", Infinity],
+              "footer-max-line-length": [0, "always", Infinity],
+              "body-leading-blank": [0, "always"]
+            }
           }' > .commitlintrc.js
       - run: npx commitlint --extends @commitlint/config-conventional --verbose <<< $COMMIT_MSG
         env:


### PR DESCRIPTION
Aligns the commitlint configuration in `.github/workflows/pr_title.yml`
with the upstream
[substrait-io/substrait](https://github.com/substrait-io/substrait/blob/main/.github/workflows/pr_title.yml)
workflow.

## Changes

- Add a second dependabot ignore regex matching the
  "Updates the requirements on ... to permit the latest version."
  messages.
- Add a `rules` block disabling `body-max-line-length`,
  `footer-max-line-length`, and `body-leading-blank`.

The `node-version` is intentionally left at `24` (upstream uses `20`),
in line with the recent node upgrade in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)