### PR TITLE
fix: add missing interval_day derivation expression

### DIFF
--- a/src/substrait/derivation_expression.py
+++ b/src/substrait/derivation_expression.py
@@ -148,6 +148,16 @@ def _evaluate(x, values: dict):
                         nullability=nullability,
                     )
                 )
+            elif isinstance(
+                parametrized_type, SubstraitTypeParser.PrecisionIntervalDayContext
+            ):
+                precision = _evaluate(parametrized_type.precision, values)
+                return Type(
+                    interval_day=Type.IntervalDay(
+                        precision=precision,
+                        nullability=nullability,
+                    )
+                )
             elif isinstance(parametrized_type, SubstraitTypeParser.StructContext):
                 types = list(
                     map(lambda x: _evaluate(x, values), parametrized_type.expr())

--- a/tests/test_derivation_expression.py
+++ b/tests/test_derivation_expression.py
@@ -116,6 +116,19 @@ DECIMAL<prec, scale>""",
     )
 
 
+def test_interval_day():
+    assert evaluate("interval_day<6>") == Type(
+        interval_day=Type.IntervalDay(
+            precision=6, nullability=Type.NULLABILITY_REQUIRED
+        )
+    )
+    assert evaluate("interval_day?<3>") == Type(
+        interval_day=Type.IntervalDay(
+            precision=3, nullability=Type.NULLABILITY_NULLABLE
+        )
+    )
+
+
 def test_struct_simple():
     """Test simple struct with two i32 fields."""
     result = evaluate("struct<i32, i32>", {})


### PR DESCRIPTION
The `_evaluate()` function in `derivation_expression.py` now returns
`Type(interval_day=Type.IntervalDay(...))` instead of raising an exception.

Fixes: #174 