### PR TITLE
fix: handle unparameterized interval_day type

### DIFF
--- a/src/substrait/derivation_expression.py
+++ b/src/substrait/derivation_expression.py
@@ -151,6 +151,12 @@ def _evaluate(x, values: dict):
             elif isinstance(
                 parametrized_type, SubstraitTypeParser.PrecisionIntervalDayContext
             ):
+                if parametrized_type.precision is None:
+                    return Type(
+                        interval_day=Type.IntervalDay(
+                            nullability=nullability,
+                        )
+                    )
                 precision = _evaluate(parametrized_type.precision, values)
                 return Type(
                     interval_day=Type.IntervalDay(

--- a/tests/test_derivation_expression.py
+++ b/tests/test_derivation_expression.py
@@ -129,6 +129,15 @@ def test_interval_day():
     )
 
 
+def test_interval_day_no_precision():
+    assert evaluate("interval_day") == Type(
+        interval_day=Type.IntervalDay(nullability=Type.NULLABILITY_REQUIRED)
+    )
+    assert evaluate("interval_day?") == Type(
+        interval_day=Type.IntervalDay(nullability=Type.NULLABILITY_NULLABLE)
+    )
+
+
 def test_struct_simple():
     """Test simple struct with two i32 fields."""
     result = evaluate("struct<i32, i32>", {})


### PR DESCRIPTION
Allow interval_day to be used without an explicit precision parameter.

Fixes: #177 