### PR TITLE
ci: expand dependabot config to cover uv and docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,28 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      substrait:
+        patterns:
+          - "substrait-protobuf"
+          - "substrait-antlr"
+          - "substrait-extensions"
+
+  - package-ecosystem: "docker"
+    directory: "/.devcontainer"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Summary

Expands the Dependabot configuration beyond the existing `github-actions` updates to cover the rest of the repo's dependency surface.

- **`uv` ecosystem** — tracks Python dependencies in `pyproject.toml` / `uv.lock`.
- **`docker` ecosystem** — tracks the base image in `.devcontainer/Dockerfile`.
- **Conventional-commit prefixes** — all ecosystems use `prefix: "chore"` + `include: "scope"`, producing messages like `chore(deps): ...` / `chore(deps-dev): ...` so generated PRs pass the PR-title check.
- **Grouping** — `substrait-protobuf`, `substrait-antlr`, and `substrait-extensions` are version-pinned together, so they're grouped into a single PR rather than three conflicting ones.

Note: `pixi.lock` is intentionally not covered, as Dependabot has no native support for pixi/conda.

🤖 Generated with AI