### PR TITLE
build: restrict permissions for commitlint

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -4,13 +4,16 @@ on:
   pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
+# Default to the minimum read-only token for all jobs.
 permissions:
-  pull-requests: write
+  contents: read
 
 jobs:
   commitlint:
     name: PR title / description conforms to semantic-release
     runs-on: ubuntu-latest
+    outputs:
+      outcome: ${{ steps.commitlint.outcome }}
     steps:
       - uses: actions/setup-node@v6
         with:
@@ -37,6 +40,14 @@ jobs:
             ${{ github.event.pull_request.title }}
 
             ${{ github.event.pull_request.body }}
+
+  comment:
+    name: Post / remove PR comment
+    runs-on: ubuntu-latest
+    needs: commitlint
+    permissions:
+      pull-requests: write
+    steps:
       - uses: actions/github-script@v9
         with:
           script: |
@@ -45,14 +56,10 @@ jobs:
             const message = `${marker}
             **ACTION NEEDED**
 
-            Substrait follows the [Conventional Commits
-            specification](https://www.conventionalcommits.org/en/v1.0.0/) for
-            release automation.
+            Substrait follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/) for release automation.
 
-            The PR title and description are used as the merge commit message.
-            Please update your PR title and description to match the specification.
-            `;
-            const passed = "${{ steps.commitlint.outcome }}" === "success";
+            The PR title and description are used as the merge commit message. Please update your PR title and description to match the specification.`;
+            const passed = "${{ needs.commitlint.outputs.outcome }}" === "success";
 
             // Find an existing comment from this job, if any.
             const comments = await github.paginate(github.rest.issues.listComments, {


### PR DESCRIPTION
The pr-title workflow gives elevated pull-request write permissions to the third-party commitlint tool. This is a potential supply-chain vulnerability.

This change restricts the permissions to only read for the commitlint tool.