### PR TITLE
build: stop running PR title check on synchronize

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,8 +1,14 @@
 name: PR Title Check
 
 on:
+  # Only the PR title and description are validated, and neither changes on a
+  # push (synchronize). Including synchronize caused a race: a Dependabot rebase
+  # force-pushes and edits the PR body at the same time, firing synchronize and
+  # edited together. Both land in the same concurrency group, so one run is
+  # cancelled, leaving a cancelled check-run on the head commit that fails the
+  # status rollup.
   pull_request_target:
-    types: [opened, edited, synchronize, reopened]
+    types: [opened, edited, reopened]
 
 # Most recent PR change supersedes previous changes.
 concurrency:


### PR DESCRIPTION
## Problem

The PR Title Check registers as failing on some PRs even though the title conforms — see #198. The check ends up with **two check-runs of the same name on the head commit**, one `SUCCESS` and one `CANCELLED`, and GitHub's status rollup treats the cancelled one as not-passing.

## Root cause

When Dependabot rebases a PR it force-pushes a new commit **and** updates the PR body in the same instant. That fires two `pull_request_target` events nearly simultaneously:

- `synchronize` — from the force-push
- `edited` — from the body update

Both resolve to the same concurrency group (`PR Title Check-<pr number>`), so `cancel-in-progress: true` cancels the first run when the second starts. Both runs had already created check-runs with identical names, leaving a dangling `CANCELLED` check-run alongside the successful one on the head commit.

The concurrency config works as intended for superseding *older commits*; it only backfires when two events land on the *same* commit.

## Fix

The check only validates the PR title and description, and neither changes on a push. So `synchronize` is both semantically unnecessary and the specific trigger racing against `edited`. Trigger only on `opened`, `edited`, and `reopened` — the events that actually change what's being validated.

🤖 Generated with AI