### PR TITLE
fix: read SetRel.common in set-relation schema inference

### DIFF
--- a/src/substrait/type_inference.py
+++ b/src/substrait/type_inference.py
@@ -429,7 +429,7 @@ def infer_rel_schema(rel: stalg.Rel) -> stt.Type.Struct:
 
         (common, struct) = (rel.project.common, raw_schema)
     elif rel_type == "set":
-        (common, struct) = (rel.fetch.common, infer_rel_schema(rel.set.inputs[0]))
+        (common, struct) = (rel.set.common, infer_rel_schema(rel.set.inputs[0]))
     elif rel_type == "cross":
         left_schema = infer_rel_schema(rel.cross.left)
         right_schema = infer_rel_schema(rel.cross.right)

--- a/tests/test_type_inference.py
+++ b/tests/test_type_inference.py
@@ -66,6 +66,27 @@ def test_inference_project_emit():
     assert infer_rel_schema(rel) == expected
 
 
+def test_inference_set_emit():
+    # A SetRel's own RelCommon.Emit must drive the output schema; regression for
+    # the branch reading rel.fetch.common instead of rel.set.common (issue #217).
+    rel = stalg.Rel(
+        set=stalg.SetRel(
+            inputs=[read_rel, read_rel],
+            op=stalg.SetRel.SET_OP_UNION_ALL,
+            common=stalg.RelCommon(emit=stalg.RelCommon.Emit(output_mapping=[2, 0])),
+        )
+    )
+
+    expected = stt.Type.Struct(
+        types=[
+            stt.Type(fp32=stt.Type.FP32(nullability=stt.Type.NULLABILITY_NULLABLE)),
+            stt.Type(i64=stt.Type.I64(nullability=stt.Type.NULLABILITY_REQUIRED)),
+        ]
+    )
+
+    assert infer_rel_schema(rel) == expected
+
+
 def test_inference_project_literal():
     rel = stalg.Rel(
         project=stalg.ProjectRel(


### PR DESCRIPTION
## Problem

`type_inference.infer_rel_schema`'s `set` branch reads the `common` from the wrong sub-message:

```python
elif rel_type == "set":
    (common, struct) = (rel.fetch.common, infer_rel_schema(rel.set.inputs[0]))
    #                    ^^^^^^^^^^^^^^^^ SetRel, so this should be rel.set.common
```

On a set-typed `Rel`, protobuf returns a default-empty `FetchRel` for `rel.fetch`, so `common` is an empty `RelCommon` whose `emit_kind` oneof is unset. The shared emit-application tail then treats it as `"direct"` and returns the first input's schema verbatim — a `SetRel` carrying a `RelCommon.Emit` (`output_mapping`) has its column remapping **silently dropped**, yielding a wrong `NamedStruct` (wrong column order, or wrong count when the mapping selects a subset).

It's a copy-paste from the adjacent `fetch` branch; every other branch reads `rel.<its own type>.common`.

## Fix

Read the `SetRel`'s own `common`. One line, plus a regression test (`test_inference_set_emit`) that builds a `SetRel` with an `output_mapping` that reorders and drops a column and asserts the remapped schema — it fails before this change and passes after.

## Scope / reachability

Not reachable through this library's own builders: only `select()` emits an `output_mapping`, and it places it on a `ProjectRel`; the `set()` builder and the `union`/`intersect`/`except_` DataFrame verbs never set `common` on a `SetRel`. So the common build-then-infer path is unaffected. The bug manifests for externally-authored / deserialized / hand-built plans passed to the public inference functions — i.e. interop with plans from other engines.

## Testing

`pytest` — 512 passed, 30 skipped (unchanged); `ruff format --check` and `ruff check` clean.

Fixes #217.

🤖 Generated with AI
