### PR TITLE
build: re-run PR title check on synchronize without cancelling

### DIFF
--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,19 +1,22 @@
 name: PR Title Check
 
 on:
-  # Only the PR title and description are validated, and neither changes on a
-  # push (synchronize). Including synchronize caused a race: a Dependabot rebase
-  # force-pushes and edits the PR body at the same time, firing synchronize and
-  # edited together. Both land in the same concurrency group, so one run is
-  # cancelled, leaving a cancelled check-run on the head commit that fails the
-  # status rollup.
+  # synchronize is required even though a push changes neither the title nor the
+  # description: "PR title / description conforms to semantic-release" is a
+  # required status check, and GitHub keys required checks to the head commit.
+  # Without synchronize, pushing a new commit strands the check on the previous
+  # commit and blocks the PR indefinitely.
   pull_request_target:
-    types: [opened, edited, reopened]
+    types: [opened, edited, synchronize, reopened]
 
-# Most recent PR change supersedes previous changes.
+# Serialize runs for the same PR so the comment job can't race with itself, but
+# never cancel in progress: a Dependabot rebase force-pushes and edits the PR
+# body at once, firing synchronize and edited on the same commit. Cancelling one
+# leaves a cancelled check-run on the head commit that fails the status rollup
+# (#198). Letting both finish yields two harmless successes instead.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Default to the minimum read-only token for all jobs.
 permissions:


### PR DESCRIPTION
## Problem

The **PR title / description conforms to semantic-release** check — a required status check on `main` — stops being reported once a PR receives a new commit, leaving the PR permanently `BLOCKED` (e.g. #224). The check runs and passes when the PR is opened, but pushing a follow-up commit never re-reports it.

## Root cause

GitHub keys required status checks to the **head commit** of the PR. #203 dropped `synchronize` from the workflow triggers (to fix the double check-run race in #198), so a push no longer runs the check. The passing check-run stays attached to the *previous* head commit, and the new head commit has no `PR title / description conforms to semantic-release` run at all — so the status rollup can never be satisfied.

Dropping `synchronize` is fundamentally incompatible with this being a required check: any contributor who pushes after opening a PR strands the required check.

## Fix

- Re-add `synchronize` so the check reports on every head commit.
- Set `cancel-in-progress: false` so the #198 race doesn't return. That race left a *cancelled* check-run because `synchronize` and `edited` (fired together by a Dependabot rebase on the same commit) landed in the same concurrency group and one cancelled the other. With cancellation disabled the second event queues behind the first and both finish as successes — two harmless `SUCCESS` check-runs instead of one `SUCCESS` + one `CANCELLED`. The concurrency group is kept so runs for a PR still serialize and the comment job can't race with itself.

🤖 Generated with AI