### PR TITLE
chore(deps)!: bump substrait packages to 0.98.0

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -59,9 +59,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
@@ -87,9 +87,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
@@ -108,9 +108,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.14.10-hb17bafe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_3.conda
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
@@ -128,9 +128,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.10-hb0cad00_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
@@ -150,9 +150,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
   dev:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -187,17 +187,17 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/00/ba/8d8aa1df96e0666752e5c9d406d440495df2014d315b2a95bbef9856b23e/datafusion-50.1.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1b/8b/5362443737a5307a7b67c1017c42cd104213189b4970bf607e05faf9c525/pyarrow-22.0.0-cp313-cp313-manylinux_2_28_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/87/0c/48ae1d485725af3a452303af409a9022d751ecab260cb9ca2f8c9fb670bc/duckdb-1.2.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl
@@ -229,16 +229,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/11/9a/afce9586145b3ed153d75364b21102a6a95260940352e06b7c6709e9d2db/datafusion-50.1.0-cp39-abi3-manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/69/c7/95fcd7bde0f754ea6700208d36b845379cbd2b28779c0eff4dd4a7396369/duckdb-1.2.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/77/dd27f6e325537126ba0b142fdce63bde4305681662ac58e8e779e3c87635/sqloxide-0.1.56-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -264,16 +264,16 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_3.conda
       - pypi: https://files.pythonhosted.org/packages/10/c7/79f57728f300079148ac4e4b988000dcbd1f58960040db89594424a58336/sqloxide-0.1.56.tar.gz
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/1f/6e/f9e2d5d935024a79fd549b5ce1d05549d26a027aab800727d492ac036504/datafusion-50.1.0-cp39-abi3-macosx_10_12_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/9f/28/943773d44fd97055c59b58dde9182733661c2b6e3b3549f15dc26b2e139e/duckdb-1.2.2-cp313-cp313-macosx_12_0_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c6/9c/1d6357347fbae062ad3f17082f9ebc29cc733321e892c0d2085f42a2212b/pyarrow-22.0.0-cp313-cp313-macosx_12_0_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
@@ -297,18 +297,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.10-hb0cad00_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/41/31/5e2f68cbd000137f6ed52092ad83a8e9c09eca70c59e0b4c5eb679709997/duckdb-1.2.2-cp313-cp313-macosx_12_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/fd/268d58f8feb4d206d2896dae5e8a4a17c671c9cbb6b15c6e6300d2e168a2/sqloxide-0.1.56-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/a6/d6/d0fac16a2963002fc22c8fa75180a838737203d558f0ed3b564c4a54eef5/pyarrow-22.0.0-cp313-cp313-macosx_12_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/db/58/2dc473240f552d3620186b527c04397f82b36f02243afaf49f0813c84a17/datafusion-50.1.0-cp39-abi3-macosx_11_0_arm64.whl
@@ -333,18 +333,18 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/2d/f8/1d0bd75bf9328a3b826e24a16e5517cd7f9fbf8d34a3184a4566ef5a7f29/pyarrow-22.0.0-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3f/3d/ce68db53084746a4a62695a4cb064e44ce04123f8582bb3afbf6ee944e16/duckdb-1.2.2-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/51/a3/41ef1c565770ef0c4060ee3fd50367dd06816f70a5be1ef41fbd7c3975e8/datafusion-50.1.0-cp39-abi3-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/5c/487e081a5ac1a8538f7eb3a3e3ea04c39da13acde1f17916ca1767d40c4e/sqloxide-0.1.56-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl
@@ -382,12 +382,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
       - pypi: https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       linux-aarch64:
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-aarch64/bzip2-1.0.8-h4777abc_8.conda
@@ -413,12 +413,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       osx-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
@@ -437,11 +437,11 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h68b038d_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/ruff-0.14.10-hb17bafe_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_3.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -460,12 +460,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h46df422_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.10-hb0cad00_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
@@ -485,12 +485,12 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc-14.3-h41ae7f8_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl
+      - pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/89/03/a851e84fcbb85214dc637b6378121ef9a0dd61b4c65264675d8a5c9b1ae7/antlr4_python3_runtime-4.13.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
   sql:
     channels:
     - url: https://conda.anaconda.org/conda-forge/
@@ -524,9 +524,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/56/13/333b8f421738f149d4fe5e49553bc2a2ab75235486259f689b4b91f96cec/protobuf-6.33.2-cp39-abi3-manylinux2014_x86_64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f9/04/98c216967275cd9a3e517dfeeb513ebff3183f1f22da29180c479c749ac8/sqloxide-0.1.56-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
       linux-aarch64:
@@ -555,9 +555,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-8_cp313.conda
       - conda: https://conda.anaconda.org/conda-forge/noarch/tzdata-2025c-hc9c84f9_1.conda
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/7d/4f/f743761e41d3b2b2566748eb76bbff2b43e14d5fcab694f494a16458b05f/protobuf-6.33.2-cp39-abi3-manylinux2014_aarch64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/de/77/dd27f6e325537126ba0b142fdce63bde4305681662ac58e8e779e3c87635/sqloxide-0.1.56-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl
       osx-64:
@@ -580,9 +580,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-hf689a15_3.conda
       - pypi: https://files.pythonhosted.org/packages/10/c7/79f57728f300079148ac4e4b988000dcbd1f58960040db89594424a58336/sqloxide-0.1.56.tar.gz
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl
       osx-arm64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-hbd8a1cb_0.conda
@@ -602,10 +602,10 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/ruff-0.14.10-hb0cad00_0.conda
       - conda: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-h892fb3f_3.conda
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/94/fd/268d58f8feb4d206d2896dae5e8a4a17c671c9cbb6b15c6e6300d2e168a2/sqloxide-0.1.56-cp313-cp313-macosx_11_0_arm64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b2/ca/7e485da88ba45c920fb3f50ae78de29ab925d9e54ef0de678306abfbb497/protobuf-6.33.2-cp39-abi3-macosx_10_9_universal2.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl
       win-64:
       - conda: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.1.4-h4c7d964_0.conda
@@ -627,9 +627,9 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/vc14_runtime-14.44.35208-h818238b_34.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/vcomp14-14.44.35208-h818238b_34.conda
       - pypi: https://files.pythonhosted.org/packages/12/27/fb8d7338b4d551900fa3e580acbe7a0cf655d940e164cb5c00ec31961094/orderly_set-5.5.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/64/20/4d50191997e917ae13ad0a235c8b42d8c1ab9c3e6fd455ca16d416944355/protobuf-6.33.2-cp310-abi3-win_amd64.whl
-      - pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-      - pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/5c/487e081a5ac1a8538f7eb3a3e3ea04c39da13acde1f17916ca1767d40c4e/sqloxide-0.1.56-cp313-cp313-win_amd64.whl
       - pypi: https://files.pythonhosted.org/packages/f7/e6/efe534ef0952b531b630780e19cabd416e2032697019d5295defc6ef9bd9/deepdiff-8.6.1-py3-none-any.whl
 packages:
@@ -1757,6 +1757,13 @@ packages:
   - pytest-cov~=6.0.0 ; extra == 'test'
   - python-dotenv~=1.0.0 ; extra == 'test'
   requires_python: '>=3.8'
+- pypi: https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl
+  name: substrait-protobuf
+  version: 0.98.0
+  sha256: c95e0579b00c1741c1a1078587987876fe27d50d05af8279853411a54d80ab64
+  requires_dist:
+  - protobuf>=5,<7
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/1b/8b/5362443737a5307a7b67c1017c42cd104213189b4970bf607e05faf9c525/pyarrow-22.0.0-cp313-cp313-manylinux_2_28_x86_64.whl
   name: pyarrow
   version: 22.0.0
@@ -1854,6 +1861,13 @@ packages:
   version: 6.33.2
   sha256: b5d3b5625192214066d99b2b605f5783483575656784de223f00a8d00754fc0e
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl
+  name: substrait-antlr
+  version: 0.98.0
+  sha256: 7b3d96294de300b9b23627f55a39a304cbace25282dd13c44f00b8d783836f63
+  requires_dist:
+  - antlr4-python3-runtime>=4.13,<5
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/87/0c/48ae1d485725af3a452303af409a9022d751ecab260cb9ca2f8c9fb670bc/duckdb-1.2.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
   name: duckdb
   version: 1.2.2
@@ -1885,18 +1899,6 @@ packages:
   version: 22.0.0
   sha256: e6e95176209257803a8b3d0394f21604e796dadb643d2f7ca21b66c9c0b30c9a
   requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl
-  name: substrait-extensions
-  version: 0.97.0
-  sha256: d60881c7b295f6171ac6e89f9a896bc11f31cf84f72a501e49c39aef6b09d21b
-  requires_python: '>=3.10'
-- pypi: https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl
-  name: substrait-protobuf
-  version: 0.97.0
-  sha256: 5be311915fc14214fc454d4e2f1ccfa4d66daa17145ce0a6227990a9c93ec00d
-  requires_dist:
-  - protobuf>=5,<7
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl
   name: pyyaml
   version: 6.0.3
@@ -1907,18 +1909,16 @@ packages:
   version: 6.33.2
   sha256: d9b19771ca75935b3a4422957bc518b0cecb978b31d1dd12037b088f6bcc0e43
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl
+  name: substrait-extensions
+  version: 0.98.0
+  sha256: a9aae65a3efb95e7ef2f49a4341b19ac00bf69bbde3d0162f3b30ef872a31619
+  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/b7/b9/c538f279a4e237a006a2c98387d081e9eb060d203d8ed34467cc0f0b9b53/packaging-26.0-py3-none-any.whl
   name: packaging
   version: '26.0'
   sha256: b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529
   requires_python: '>=3.8'
-- pypi: https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl
-  name: substrait-antlr
-  version: 0.97.0
-  sha256: 8563658900cee846f20b781e8ea476ab3b223311956cd89ac8ca6efd6db6c4e7
-  requires_dist:
-  - antlr4-python3-runtime>=4.13,<5
-  requires_python: '>=3.10'
 - pypi: https://files.pythonhosted.org/packages/c6/9c/1d6357347fbae062ad3f17082f9ebc29cc733321e892c0d2085f42a2212b/pyarrow-22.0.0-cp313-cp313-macosx_12_0_x86_64.whl
   name: pyarrow
   version: 22.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,8 +7,8 @@ readme = "README.md"
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "protobuf >=5,<7",
-    "substrait-protobuf==0.97.0",
-    "substrait-extensions==0.97.0",
+    "substrait-protobuf==0.98.0",
+    "substrait-extensions==0.98.0",
 ]
 dynamic = ["version"]
 
@@ -16,11 +16,11 @@ dynamic = ["version"]
 write_to = "src/substrait/_version.py"
 
 [project.optional-dependencies]
-extensions = ["substrait-antlr==0.97.0", "pyyaml"]
+extensions = ["substrait-antlr==0.98.0", "pyyaml"]
 sql = ["sqloxide", "deepdiff"]
 
 [dependency-groups]
-dev = ["pytest >= 7.0.0", "substrait-antlr==0.97.0", "pyyaml", "sqloxide", "deepdiff", "duckdb<=1.2.2; python_version < '3.14'", "datafusion"]
+dev = ["pytest >= 7.0.0", "substrait-antlr==0.98.0", "pyyaml", "sqloxide", "deepdiff", "duckdb<=1.2.2; python_version < '3.14'", "datafusion"]
 
 [tool.pytest.ini_options]
 pythonpath = "src"

--- a/src/substrait/utils/display.py
+++ b/src/substrait/utils/display.py
@@ -189,25 +189,16 @@ class PlanPrinter:
             stream.write(
                 f"{indent}{self._color('read:', Colors.GREEN)} {self._color('virtual_table', Colors.YELLOW)}\n"
             )
-            if read.virtual_table.values:
+            rows = read.virtual_table.expressions
+            if rows:
                 stream.write(
-                    f"{self._get_indent_with_arrow(depth + 1)}{self._color('values:', Colors.BLUE)} {self._color(len(read.virtual_table.values), Colors.YELLOW)}\n"
+                    f"{self._get_indent_with_arrow(depth + 1)}{self._color('rows:', Colors.BLUE)} {self._color(len(rows), Colors.YELLOW)}\n"
                 )
-                # Show the actual values, not just count
-                for i, value in enumerate(read.virtual_table.values):
-                    # Handle struct values properly
-                    if hasattr(value, "fields"):
-                        stream.write(
-                            f"{self._get_indent_with_arrow(depth + 2)}value[{i}]: "
-                        )
-                        self._stream_struct_literal(
-                            value, stream, depth + 2, inline=True
-                        )
-                    else:
-                        stream.write(
-                            f"{self._get_indent_with_arrow(depth + 2)}value[{i}]: "
-                        )
-                        self._stream_literal_value(value, stream, depth + 2)
+                # Each row is a struct expression; show its field expressions.
+                for i, row in enumerate(rows):
+                    stream.write(f"{self._get_indent_with_arrow(depth + 2)}row[{i}]:\n")
+                    for field in row.fields:
+                        self._stream_expression(field, stream, depth + 3)
 
         if read.HasField("base_schema"):
             # Capture schema names for field resolution
@@ -319,12 +310,29 @@ class PlanPrinter:
         )
         self._stream_rel(cross.right, stream, depth + 1)
 
+    @staticmethod
+    def _fetch_bound_str(fetch: stalg.FetchRel, field: str, default: str) -> str:
+        """Compact string for a FetchRel ``offset_expr``/``count_expr`` bound.
+
+        Returns the i64 literal value when the bound is a simple integer literal
+        (what the ``fetch`` builder always emits), ``default`` when the field is
+        unset, or ``<expr>`` for any other (non-literal) expression.
+        """
+        if not fetch.HasField(field):
+            return default
+        expr = getattr(fetch, field)
+        if expr.HasField("literal") and expr.literal.HasField("i64"):
+            return str(expr.literal.i64)
+        return "<expr>"
+
     def _stream_fetch_rel(self, fetch: stalg.FetchRel, stream, depth: int):
         """Print a fetch relation concisely"""
         indent = " " * (depth * self.indent_size)
 
+        offset = self._fetch_bound_str(fetch, "offset_expr", default="0")
+        count = self._fetch_bound_str(fetch, "count_expr", default="all")
         stream.write(
-            f"{indent}{self._color('fetch:', Colors.YELLOW)} {self._color(f'offset={fetch.offset}, count={fetch.count}', Colors.YELLOW)}\n"
+            f"{indent}{self._color('fetch:', Colors.YELLOW)} {self._color(f'offset={offset}, count={count}', Colors.YELLOW)}\n"
         )
         stream.write(
             f"{self._get_indent_with_arrow(depth + 1)}{self._color('input:', Colors.BLUE)}\n"
@@ -776,54 +784,6 @@ class PlanPrinter:
             stream.write(
                 f"{indent}{self._color('<unknown_literal_type>', Colors.RED)}\n"
             )
-
-    def _stream_struct_literal(
-        self, struct_literal, stream, depth: int, inline: bool = False
-    ):
-        """Print a struct literal value with proper indentation"""
-        if inline:
-            # When inline, don't add extra indentation since we're already on the same line
-            indent = ""
-        else:
-            indent = " " * (depth * self.indent_size)
-
-        if hasattr(struct_literal, "fields") and struct_literal.fields:
-            stream.write(f"{indent}{self._color('struct', Colors.BLUE)}\n")
-            for i, field in enumerate(struct_literal.fields):
-                # Show field index
-                stream.write(f"{self._get_indent_with_arrow(depth + 1)}field[{i}]:\n")
-                # Show the actual field value with proper indentation
-                if field.HasField("i64"):
-                    stream.write(
-                        f"{self._get_indent_with_arrow(depth + 2)}{self._color('i64', Colors.BLUE)}: {self._color(field.i64, Colors.GREEN)}\n"
-                    )
-                elif field.HasField("fp64"):
-                    stream.write(
-                        f"{self._get_indent_with_arrow(depth + 2)}{self._color('fp64', Colors.BLUE)}: {self._color(field.fp64, Colors.GREEN)}\n"
-                    )
-                elif field.HasField("fp32"):
-                    stream.write(
-                        f"{self._get_indent_with_arrow(depth + 2)}{self._color('fp32', Colors.BLUE)}: {self._color(field.fp32, Colors.GREEN)}\n"
-                    )
-                elif field.HasField("i32"):
-                    stream.write(
-                        f"{self._get_indent_with_arrow(depth + 2)}{self._color('i32', Colors.BLUE)}: {self._color(field.i32, Colors.GREEN)}\n"
-                    )
-                elif field.HasField("string"):
-                    field_string_value = f'"{field.string}"'
-                    stream.write(
-                        f"{self._get_indent_with_arrow(depth + 2)}{self._color('string', Colors.BLUE)}: {self._color(field_string_value, Colors.GREEN)}\n"
-                    )
-                elif field.HasField("boolean"):
-                    stream.write(
-                        f"{self._get_indent_with_arrow(depth + 2)}{self._color('boolean', Colors.BLUE)}: {self._color(field.boolean, Colors.GREEN)}\n"
-                    )
-                else:
-                    stream.write(
-                        f"{self._get_indent_with_arrow(depth + 2)}{self._color('<unknown_field_type>', Colors.RED)}\n"
-                    )
-        else:
-            stream.write(f"{indent}{self._color('empty_struct', Colors.YELLOW)}\n")
 
     def _type_to_string(self, type_info: stt.Type) -> str:
         """Convert a type to a concise string representation"""

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -1,0 +1,55 @@
+import substrait.type_pb2 as stt
+
+from substrait.builders.extended_expression import literal
+from substrait.builders.plan import fetch, read_named_table, virtual_table
+from substrait.builders.type import boolean, i64
+from substrait.extension_registry import ExtensionRegistry
+from substrait.utils.display import PlanPrinter
+
+registry = ExtensionRegistry(load_default_extensions=False)
+
+struct = stt.Type.Struct(
+    types=[i64(nullable=False), boolean()], nullability=stt.Type.NULLABILITY_REQUIRED
+)
+named_struct = stt.NamedStruct(names=["id", "flag"], struct=struct)
+
+
+def _printer() -> PlanPrinter:
+    return PlanPrinter(use_colors=False)
+
+
+def test_stringify_virtual_table_renders_row_expressions():
+    rows = [
+        [literal(1, i64(nullable=False)), literal(True, boolean())],
+        [literal(2, i64(nullable=False)), literal(False, boolean())],
+    ]
+    plan = virtual_table(rows, named_struct)(registry)
+
+    out = _printer().stringify_plan(plan)
+
+    assert "read: virtual_table" in out
+    assert "rows: 2" in out
+    assert "row[0]:" in out
+    assert "row[1]:" in out
+    # Row expressions are rendered as literals.
+    assert "literal: 1" in out
+    assert "literal: False" in out
+
+
+def test_stringify_fetch_with_offset_and_count():
+    table = read_named_table("t", named_struct)
+    plan = fetch(table, offset=literal(10, i64()), count=literal(5, i64()))(registry)
+
+    out = _printer().stringify_plan(plan)
+
+    assert "fetch: offset=10, count=5" in out
+
+
+def test_stringify_fetch_unset_offset_and_count():
+    table = read_named_table("t", named_struct)
+    # offset unset defaults to 0; count=None means "all remaining rows".
+    plan = fetch(table, offset=None, count=None)(registry)
+
+    out = _printer().stringify_plan(plan)
+
+    assert "fetch: offset=0, count=all" in out

--- a/uv.lock
+++ b/uv.lock
@@ -525,9 +525,9 @@ requires-dist = [
     { name = "protobuf", specifier = ">=5,<7" },
     { name = "pyyaml", marker = "extra == 'extensions'" },
     { name = "sqloxide", marker = "extra == 'sql'" },
-    { name = "substrait-antlr", marker = "extra == 'extensions'", specifier = "==0.97.0" },
-    { name = "substrait-extensions", specifier = "==0.97.0" },
-    { name = "substrait-protobuf", specifier = "==0.97.0" },
+    { name = "substrait-antlr", marker = "extra == 'extensions'", specifier = "==0.98.0" },
+    { name = "substrait-extensions", specifier = "==0.98.0" },
+    { name = "substrait-protobuf", specifier = "==0.98.0" },
 ]
 provides-extras = ["extensions", "sql"]
 
@@ -539,40 +539,40 @@ dev = [
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pyyaml" },
     { name = "sqloxide" },
-    { name = "substrait-antlr", specifier = "==0.97.0" },
+    { name = "substrait-antlr", specifier = "==0.98.0" },
 ]
 
 [[package]]
 name = "substrait-antlr"
-version = "0.97.0"
+version = "0.98.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "antlr4-python3-runtime" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/d1/a55cdeaccbc841fa6e0e18384883fad01ab41eaa78b4b4ebfc5589a41b5d/substrait_antlr-0.97.0.tar.gz", hash = "sha256:986f488beaab729abf86dacda371039e9d2c2d4827c132850c941cf1b8efdb71", size = 69274, upload-time = "2026-07-12T05:23:52.41Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/30/192c586bb8ea222a353c0b128bacd55ea05056f119cb87f248d5896c9962/substrait_antlr-0.98.0.tar.gz", hash = "sha256:6a1f33bcd88c425229e42c77079fb0f1f5ad8e0da133e9c1e68048c47104f059", size = 69278, upload-time = "2026-07-19T05:18:20.206Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c0/f6/28b4983b3e6c960b113ebddb130bae2ca5ea86d8d13aa8596376742900a7/substrait_antlr-0.97.0-py3-none-any.whl", hash = "sha256:8563658900cee846f20b781e8ea476ab3b223311956cd89ac8ca6efd6db6c4e7", size = 78335, upload-time = "2026-07-12T05:23:53.35Z" },
+    { url = "https://files.pythonhosted.org/packages/80/f4/44b3e9c4c13dae13038b524a2ff40abd12da55ade42dc4abc32156fff014/substrait_antlr-0.98.0-py3-none-any.whl", hash = "sha256:7b3d96294de300b9b23627f55a39a304cbace25282dd13c44f00b8d783836f63", size = 78336, upload-time = "2026-07-19T05:18:19.122Z" },
 ]
 
 [[package]]
 name = "substrait-extensions"
-version = "0.97.0"
+version = "0.98.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/87/7f/1fe68a0e1c485b6692a114b24dcfbec3fa1fcbc0682d382b10cb35931bf4/substrait_extensions-0.97.0.tar.gz", hash = "sha256:f769f320f942408816cea554865664e06fe960823e1cd029aebb8b951efb8fc3", size = 57110, upload-time = "2026-07-12T05:23:54.068Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/45/08a9437d47ae23bcd22ce0b45dd8e10eb3b7bbcdb51115e9ed8b6afdcd80/substrait_extensions-0.98.0.tar.gz", hash = "sha256:fc8dfd3637c4e3846ded455a0d206d80207b42fd6473a064de3c3871b3b8397c", size = 57105, upload-time = "2026-07-19T05:18:24.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a9/d9/08b31b0c213449def6e2fff8d892762748ac31d59069d6adbf40bdb12359/substrait_extensions-0.97.0-py3-none-any.whl", hash = "sha256:d60881c7b295f6171ac6e89f9a896bc11f31cf84f72a501e49c39aef6b09d21b", size = 113281, upload-time = "2026-07-12T05:23:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/a7/e4a8c260966fdb780633c32e522b721f4136a2f83c757db084d08c7b3976/substrait_extensions-0.98.0-py3-none-any.whl", hash = "sha256:a9aae65a3efb95e7ef2f49a4341b19ac00bf69bbde3d0162f3b30ef872a31619", size = 113286, upload-time = "2026-07-19T05:18:23.949Z" },
 ]
 
 [[package]]
 name = "substrait-protobuf"
-version = "0.97.0"
+version = "0.98.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "protobuf" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/12/91e5e8f670a5ba4da01bdc5368363aaac90be609e09a3c71885a218e39cb/substrait_protobuf-0.97.0.tar.gz", hash = "sha256:d6be4ef0c2ad31b5ca2294e668d8dd02738940f680ffda1d4ae80e07b9614ef3", size = 65450, upload-time = "2026-07-12T05:24:03.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/6f/399a387ae9cf854880b6f32142e6196fe2b4b7e903442cfb85c1f01094ca/substrait_protobuf-0.98.0.tar.gz", hash = "sha256:cfd170901725a8b1c51f040c43a68e0dbedf8804cad1e928b348738e09317064", size = 64875, upload-time = "2026-07-19T05:18:26.126Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/49/2783523b77f1500141785de890cda1b8bd886d07703254594b26ecc70c11/substrait_protobuf-0.97.0-py3-none-any.whl", hash = "sha256:5be311915fc14214fc454d4e2f1ccfa4d66daa17145ce0a6227990a9c93ec00d", size = 71373, upload-time = "2026-07-12T05:24:02.052Z" },
+    { url = "https://files.pythonhosted.org/packages/12/cc/243e45399f8c2cc15d36bb8b1a952214117487ed3a44cfe2ab3a50a0936a/substrait_protobuf-0.98.0-py3-none-any.whl", hash = "sha256:c95e0579b00c1741c1a1078587987876fe27d50d05af8279853411a54d80ab64", size = 70693, upload-time = "2026-07-19T05:18:24.926Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Updates the substrait packages to **0.98.0** (closes #226) and adapts the plan printer to the proto fields removed in this release.

- Bump `substrait-protobuf`, `substrait-extensions`, and `substrait-antlr` from `0.97.0` → `0.98.0`; regenerate `uv.lock` and `pixi.lock`.
- Fix two latent crashes in `substrait.utils.display`: the printer read the deprecated `FetchRel.offset`/`count` and `ReadRel.VirtualTable.values` fields, which raise `AttributeError` under 0.98.0. It now renders `offset_expr`/`count_expr` and the `VirtualTable` `expressions`.
- Remove the now-dead `_stream_struct_literal` helper (its only caller was the removed `VirtualTable.values` path).
- Add `tests/test_display.py` covering the virtual-table and fetch display paths, which had no test coverage.

## Breaking changes in substrait 0.98.0

The 0.98.0 protos remove several long-deprecated fields:

| Removed field | Replacement | Status in this repo |
|---|---|---|
| `HashJoinRel`/`MergeJoinRel` `left_keys`/`right_keys` | `keys` | Builders already use `keys` — no change |
| `FetchRel` `offset`/`count` | `offset_expr`/`count_expr` | Builders already emit `*_expr`; display fixed here |
| `ReadRel.VirtualTable.values` | `expressions` | Builder already uses `expressions`; display fixed here |
| `IntervalDayToSecond.microseconds` | `subseconds` (+ `precision`) | Builder already uses `subseconds`/`precision` — no change |

No public builder/consumer API change is required. The only user-visible behaviour change is the plan printer's virtual-table output, which now reuses the shared expression renderer (`literal: <value>`) instead of the removed field-typed struct renderer.

## Stacking

This is stacked on top of #230 (bump to 0.97.0), which is not yet merged. Until #230 lands, this PR's diff will also include the 0.97.0 changes; once #230 merges to `main`, only the 0.97.0 → 0.98.0 delta will remain. **Merge #230 first.**

## Testing

- `pixi run -e dev pytest` → 546 passed, 30 skipped
- `pixi run lint` → clean
- `pixi run format --check` → clean

🤖 Generated with AI