### PR TITLE
fix!: make OuterReference.steps_out 1-based per the Substrait spec

### DIFF
--- a/src/substrait/builders/extended_expression.py
+++ b/src/substrait/builders/extended_expression.py
@@ -337,21 +337,26 @@ def literal(
     return resolve
 
 
-def outer_reference(field: Union[str, int], steps_out: int = 0):
+def outer_reference(field: Union[str, int], steps_out: int = 1):
     """A field reference to an enclosing query's column (a correlated reference).
 
     Only valid inside a subquery; ``steps_out`` counts query-nesting levels
-    outward (0 = the immediately enclosing query). ``field`` is resolved against
-    that enclosing query's schema.
+    outward (1 = the immediately enclosing query), matching Substrait's
+    requirement that ``steps_out`` be >= 1. ``field`` is resolved against that
+    enclosing query's schema.
     """
 
     def resolve(
         base_schema: stp.NamedStruct, registry: ExtensionRegistry
     ) -> stee.ExtendedExpression:
+        if steps_out < 1:
+            raise ValueError(
+                "steps_out must be >= 1 (1 = the immediately enclosing query)"
+            )
         stack = outer_schemas.get()
-        if steps_out >= len(stack):
+        if steps_out > len(stack):
             raise Exception("outer() is only valid inside a correlated subquery")
-        outer_ns = stack[len(stack) - 1 - steps_out]
+        outer_ns = stack[len(stack) - steps_out]
         # Resolve the column against the enclosing schema, then re-root it as an
         # outer reference (keeping the resolved struct-field segment).
         resolved = column(field)(outer_ns, registry).referred_expr[0]

--- a/src/substrait/dataframe/expr.py
+++ b/src/substrait/dataframe/expr.py
@@ -1023,15 +1023,16 @@ def col(name: Union[str, int]) -> Expr:
     return Expr(column(name))
 
 
-def outer(name: Union[str, int], steps_out: int = 0) -> Expr:
+def outer(name: Union[str, int], steps_out: int = 1) -> Expr:
     """Reference a column from an enclosing query (a correlated reference).
 
     Only valid inside a subquery, e.g. a correlated ``exists``::
 
         outer_df.filter(sub.exists(inner_df.filter(sub.col("k") == sub.outer("k"))))
 
-    ``steps_out`` counts query-nesting levels outward (0 = the immediately
-    enclosing query).
+    ``steps_out`` counts query-nesting levels outward (1 = the immediately
+    enclosing query), matching Substrait's requirement that ``steps_out`` be
+    >= 1.
     """
     return Expr(_outer_reference(name, steps_out))
 

--- a/src/substrait/type_inference.py
+++ b/src/substrait/type_inference.py
@@ -215,12 +215,19 @@ def infer_expression_type(
         # the lambda's parameter struct; otherwise against the input row.
         if root_type == "outer_reference":
             stack = outer_schemas.get()
+            # steps_out is 1-based per the Substrait spec (1 = the immediately
+            # enclosing query), so it indexes back from the top of the stack.
             steps = expression.selection.outer_reference.steps_out
-            if steps >= len(stack):
+            if steps < 1:
+                raise Exception(
+                    f"outer reference has steps_out={steps}; Substrait requires "
+                    "steps_out >= 1 (1 = the immediately enclosing query)"
+                )
+            if steps > len(stack):
                 raise Exception(
                     "outer reference outside an enclosing (correlated) query"
                 )
-            schema = stack[len(stack) - 1 - steps].struct
+            schema = stack[len(stack) - steps].struct
         else:
             assert root_type in ("root_reference", "lambda_parameter_reference")
             schema = parent_schema

--- a/tests/dataframe/test_frame.py
+++ b/tests/dataframe/test_frame.py
@@ -1060,7 +1060,7 @@ def test_correlated_exists():
     lhs, rhs = (a.value.selection for a in inner_cond.scalar_function.arguments)
     assert lhs.WhichOneof("root_type") == "root_reference"  # inner.k
     assert rhs.WhichOneof("root_type") == "outer_reference"  # outer.k
-    assert rhs.outer_reference.steps_out == 0
+    assert rhs.outer_reference.steps_out == 1  # 1 = the immediately enclosing query
     assert rhs.direct_reference.struct_field.field == 0  # "k" in the outer schema
 
 
@@ -1076,8 +1076,8 @@ def test_nested_correlation_steps_out():
     outer = sub.read_named_table("o", {"k": sub.i64})
     mid = sub.read_named_table("m", {"k": sub.i64})
     inner = sub.read_named_table("i", {"k": sub.i64})
-    # innermost references the outermost query -> steps_out=1
-    inner_corr = inner.filter(sub.col("k") == sub.outer("k", steps_out=1))
+    # innermost references the outermost query -> steps_out=2 (two levels out)
+    inner_corr = inner.filter(sub.col("k") == sub.outer("k", steps_out=2))
     mid_corr = mid.filter(sub.exists(inner_corr))
     plan = outer.filter(sub.exists(mid_corr)).to_plan()
 
@@ -1085,13 +1085,22 @@ def test_nested_correlation_steps_out():
         -1
     ].root.input.filter.condition.subquery.set_predicate.tuples.filter.condition.subquery.set_predicate.tuples.filter.condition  # mid  # inner
     rhs = inner_cond.scalar_function.arguments[1].value.selection
-    assert rhs.outer_reference.steps_out == 1  # two levels out -> the outermost
+    assert rhs.outer_reference.steps_out == 2  # two levels out -> the outermost
 
 
 def test_outer_outside_subquery_raises():
     df = sub.read_named_table("t", {"x": sub.i64})
     with pytest.raises(Exception, match="correlated subquery"):
         df.filter(sub.col("x") == sub.outer("x")).to_plan()
+
+
+def test_outer_steps_out_below_one_raises():
+    # Substrait requires steps_out >= 1; the 0-based convention is rejected.
+    outer = sub.read_named_table("o", {"k": sub.i64})
+    inner = sub.read_named_table("i", {"k": sub.i64})
+    corr = inner.filter(sub.col("k") == sub.outer("k", steps_out=0))
+    with pytest.raises(ValueError, match="steps_out must be >= 1"):
+        outer.filter(sub.exists(corr)).to_plan()
 
 
 def test_correlated_subquery_projecting_outer_column_then_chaining():


### PR DESCRIPTION
## Summary

`OuterReference.steps_out` used a **0-based** convention in substrait-python (`0` = the immediately enclosing query), but Substrait requires `steps_out` to be **>= 1** (1-based) — see `proto/substrait/algebra.proto` (`steps_out ... Must be >= 1`) and the v0.89.0 release note for #188. Plans emitted with `steps_out=0` violate the spec and are off-by-one for deeper nesting, so correlated subqueries may not round-trip with spec-conformant producers/consumers.

Fixes #231.

## Changes

- **`builders/extended_expression.py`** — `outer_reference(field, steps_out=1)`: default is now `1`, the emitted `OuterReference.steps_out` and the enclosing-schema stack index are 1-based, and `steps_out < 1` raises a clear `ValueError`.
- **`dataframe/expr.py`** — `sub.outer(name, steps_out=1)`: matching 1-based default and docstring.
- **`type_inference.py`** — the `outer_reference` branch indexes the enclosing-query stack 1-based to match, and raises a clear error for an out-of-spec `steps_out < 1` (also avoids an index-out-of-range).
- **Tests** — updated `test_correlated_exists` (immediate correlation now asserts `steps_out == 1`) and `test_nested_correlation_steps_out` (two levels out is now `steps_out == 2`); added `test_outer_steps_out_below_one_raises`.

The lateral-join path (`OuterReference.rel_reference`, id-based) does not use `steps_out` and is unaffected.

## Breaking change

`outer_reference()` / `sub.outer()` are now 1-based. `steps_out=1` (the new default) selects the immediately enclosing query where `steps_out=0` did before; add 1 to each existing `steps_out` value.

## Testing

- `pixi run -e dev python -m pytest` — 544 passed, 30 skipped
- `pixi run lint` and `pixi run format --check` — clean

🤖 Generated with AI