### PR TITLE
docs: introduce the DataFrame API in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,38 @@ This project is not an execution engine for Substrait Plans.
 ## Status
 This is an experimental package that is still under development.
 
-# Example
+# Building plans with the DataFrame API
+
+The `substrait.dataframe` module is an ergonomic, fluent API for authoring
+Substrait plans — a Polars/PySpark-style DataFrame with operator-overloaded
+expressions, on top of the lower-level builders. It is the recommended way to
+build plans by hand:
+
+```python
+import substrait.dataframe as sub
+
+plan = (
+    sub.read_named_table("people", {"id": sub.i64, "age": sub.i64, "name": sub.string})
+    .filter(sub.col("age") > 25)
+    .with_columns(adult=sub.col("age") >= 18)
+    .select("id", "name", "adult")
+    .to_plan()
+)
+```
+
+`plan` is a `substrait.proto.Plan` ready to hand to a consumer such as DuckDB or
+DataFusion. Install the `extensions` extra so function overloads resolve against
+the standard Substrait extensions:
+
+```sh
+pip install "substrait[extensions]"
+```
+
+# Example (low-level API)
+
+The examples below construct plans with the raw `substrait.proto` and
+`substrait.builders` layers. For most hand-authored plans, prefer the
+[DataFrame API](#building-plans-with-the-dataframe-api) above.
 
 ## Produce a Substrait Plan
 The ``substrait.proto`` module provides access to the classes


### PR DESCRIPTION
## What

Adds a **Building plans with the DataFrame API** section to the README, leading
with the ergonomic `substrait.dataframe` API (introduced in #204), and reframes
the existing raw `substrait.proto` / `substrait.builders` examples as the
low-level API.

Previously the README led straight into verbose raw-`proto` plan construction,
with no mention of the DataFrame API that already ships on `main`.

## Why a separate PR

These README changes are extracted from the user guide PR (#214) so they can
land independently while that larger guide is being finalized. Everything here
is self-contained against `main`:

- The DataFrame snippet is the module's own docstring example and was run
  end to end (it produces a `substrait.proto.Plan`).
- The `extensions` extra referenced for function resolution exists in
  `pyproject.toml`.

The guide-link paragraph from #214 (pointing at `docs/index.md` and
`pixi run docs-serve`) is intentionally **omitted** here, since those docs and
tasks only exist in #214 — including it now would leave a broken link on `main`.
#214 re-adds that pointer when the guide lands.

## Verification

Ran the new README example against the current API:

```python
import substrait.dataframe as sub

plan = (
    sub.read_named_table("people", {"id": sub.i64, "age": sub.i64, "name": sub.string})
    .filter(sub.col("age") > 25)
    .with_columns(adult=sub.col("age") >= 18)
    .select("id", "name", "adult")
    .to_plan()
)
# -> substrait.proto.Plan
```

🤖 Generated with AI